### PR TITLE
Fix hanging edges (fixes #142, fixes #152, fixes #158)

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/EdgeConnectorListener.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/EdgeConnectorListener.cs
@@ -5,7 +5,7 @@ using Edge = UnityEditor.Experimental.UIElements.GraphView.Edge;
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
-    public class EdgeConnectorListener : IEdgeConnectorListener
+    class EdgeConnectorListener : IEdgeConnectorListener
     {
         readonly AbstractMaterialGraph m_Graph;
         readonly SearchWindowProvider m_SearchWindowProvider;
@@ -19,14 +19,14 @@ namespace UnityEditor.ShaderGraph.Drawing
         public void OnDropOutsidePort(Edge edge, Vector2 position)
         {
             var draggedPort = (edge.output != null ? edge.output.edgeConnector.edgeDragHelper.draggedPort : null) ?? (edge.input != null ? edge.input.edgeConnector.edgeDragHelper.draggedPort : null);
-            m_SearchWindowProvider.connectedPort = draggedPort;
+            m_SearchWindowProvider.connectedPort = (ShaderPort) draggedPort;
             SearchWindow.Open(new SearchWindowContext(GUIUtility.GUIToScreenPoint(Event.current.mousePosition)), m_SearchWindowProvider);
         }
 
         public void OnDrop(GraphView graphView, Edge edge)
         {
-            var leftSlot = edge.output.userData as ISlot;
-            var rightSlot = edge.input.userData as ISlot;
+            var leftSlot = edge.output.GetSlot();
+            var rightSlot = edge.input.GetSlot();
             if (leftSlot != null && rightSlot != null)
             {
                 m_Graph.owner.RegisterCompleteObjectUndo("Connect Edge");

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/SearchWindowProvider.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/SearchWindowProvider.cs
@@ -11,13 +11,13 @@ using INode = UnityEditor.Graphing.INode;
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
-    public class SearchWindowProvider : ScriptableObject, ISearchWindowProvider
+    class SearchWindowProvider : ScriptableObject, ISearchWindowProvider
     {
         EditorWindow m_EditorWindow;
         AbstractMaterialGraph m_Graph;
         GraphView m_GraphView;
         Texture2D m_Icon;
-        public Port connectedPort { get; set; }
+        public ShaderPort connectedPort { get; set; }
         public bool nodeNeedsRepositioning { get; set; }
         public SlotReference targetSlotReference { get; private set; }
         public Vector2 targetPosition { get; private set; }
@@ -175,7 +175,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         int GetFirstCompatibleSlotId(AbstractMaterialNode node)
         {
-            var connectedSlot = (MaterialSlot)connectedPort.userData;
+            var connectedSlot = connectedPort.slot;
             m_Slots.Clear();
             node.GetSlots(m_Slots);
             foreach (var slot in m_Slots)
@@ -205,7 +205,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             if (connectedPort != null)
             {
-                var connectedSlot = (MaterialSlot)connectedPort.userData;
+                var connectedSlot = connectedPort.slot;
                 var connectedSlotReference = connectedSlot.owner.GetSlotReference(connectedSlot.id);
                 var compatibleSlotReference = node.GetSlotReference(nodeEntry.compatibleSlotId);
 

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/GraphEditorView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/GraphEditorView.cs
@@ -159,8 +159,8 @@ namespace UnityEditor.ShaderGraph.Drawing
             {
                 foreach (var edge in graphViewChange.edgesToCreate)
                 {
-                    var leftSlot = edge.output.userData as ISlot;
-                    var rightSlot = edge.input.userData as ISlot;
+                    var leftSlot = edge.output.GetSlot();
+                    var rightSlot = edge.input.GetSlot();
                     if (leftSlot != null && rightSlot != null)
                     {
                         m_Graph.owner.RegisterCompleteObjectUndo("Connect Edge");
@@ -304,8 +304,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                     var port = element as ShaderPort;
                     if (port == null)
                         continue;
-                    var slot = (MaterialSlot)port.userData;
-                    if (slot.slotReference.Equals(m_SearchWindowProvider.targetSlotReference))
+                    if (port.slot.slotReference.Equals(m_SearchWindowProvider.targetSlotReference))
                     {
                         port.RegisterCallback<PostLayoutEvent>(RepositionNode);
                         return;
@@ -355,10 +354,10 @@ namespace UnityEditor.ShaderGraph.Drawing
             var sourceNodeView = m_GraphView.nodes.ToList().OfType<MaterialNodeView>().FirstOrDefault(x => x.node == sourceNode);
             if (sourceNodeView != null)
             {
-                var sourceAnchor = sourceNodeView.outputContainer.Children().OfType<Port>().FirstOrDefault(x => x.userData is ISlot && (x.userData as ISlot).Equals(sourceSlot));
+                var sourceAnchor = sourceNodeView.outputContainer.Children().OfType<ShaderPort>().FirstOrDefault(x => x.slot.Equals(sourceSlot));
 
                 var targetNodeView = m_GraphView.nodes.ToList().OfType<MaterialNodeView>().FirstOrDefault(x => x.node == targetNode);
-                var targetAnchor = targetNodeView.inputContainer.Children().OfType<Port>().FirstOrDefault(x => x.userData is ISlot && (x.userData as ISlot).Equals(targetSlot));
+                var targetAnchor = targetNodeView.inputContainer.Children().OfType<ShaderPort>().FirstOrDefault(x => x.slot.Equals(targetSlot));
 
                 var edgeView = new Edge
                 {
@@ -396,7 +395,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 {
                     foreach (var edgeView in anchorView.connections.OfType<Edge>())
                     {
-                        var targetSlot = (MaterialSlot)edgeView.input.userData;
+                        var targetSlot = edgeView.input.GetSlot();
                         if (targetSlot.valueType == SlotValueType.Dynamic)
                         {
                             var connectedNodeView = edgeView.input.node as MaterialNodeView;
@@ -410,7 +409,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 }
                 foreach (var anchorView in nodeView.inputContainer.Children().OfType<Port>())
                 {
-                    var targetSlot = (MaterialSlot)anchorView.userData;
+                    var targetSlot = anchorView.GetSlot();
                     if (targetSlot.valueType != SlotValueType.Dynamic)
                         continue;
                     foreach (var edgeView in anchorView.connections.OfType<Edge>())

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/MaterialGraphView.cs
@@ -21,7 +21,7 @@ namespace UnityEditor.ShaderGraph.Drawing
         public override List<Port> GetCompatiblePorts(Port startAnchor, NodeAdapter nodeAdapter)
         {
             var compatibleAnchors = new List<Port>();
-            var startSlot = startAnchor.userData as MaterialSlot;
+            var startSlot = startAnchor.GetSlot();
             if (startSlot == null)
                 return compatibleAnchors;
 
@@ -31,7 +31,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             foreach (var candidateAnchor in ports.ToList())
             {
-                var candidateSlot = candidateAnchor.userData as MaterialSlot;
+                var candidateSlot = candidateAnchor.GetSlot();
                 if (!startSlot.IsCompatibleWith(candidateSlot))
                     continue;
 

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/ShaderPort.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/ShaderPort.cs
@@ -10,19 +10,45 @@ namespace UnityEditor.ShaderGraph.Drawing
         ShaderPort(Orientation portOrientation, Direction portDirection, Type type)
             : base(portOrientation, portDirection, type) { }
 
-        public static Port Create(Orientation orientation, Direction direction, Type type, IEdgeConnectorListener connectorListener)
+        MaterialSlot m_Slot;
+
+        public static Port Create(MaterialSlot slot, IEdgeConnectorListener connectorListener)
         {
-            var port = new ShaderPort(orientation, direction, type)
+            var port = new ShaderPort(Orientation.Horizontal, slot.isInputSlot ? Direction.Input : Direction.Output, null)
             {
                 m_EdgeConnector = new EdgeConnector<Edge>(connectorListener),
             };
             port.AddManipulator(port.m_EdgeConnector);
+            port.slot = slot;
+            port.portName = slot.displayName;
+            port.visualClass = slot.concreteValueType.ToClassName();
             return port;
         }
 
-        public VisualElement connectorBox
+        public MaterialSlot slot
         {
-            get { return m_ConnectorBox; }
+            get { return m_Slot; }
+            set
+            {
+                if (ReferenceEquals(value, m_Slot))
+                    return;
+                if (value == null)
+                    throw new NullReferenceException();
+                if (m_Slot != null && value.isInputSlot != m_Slot.isInputSlot)
+                    throw new ArgumentException("Cannot change direction of already created port");
+                m_Slot = value;
+                portName = slot.displayName;
+                visualClass = slot.concreteValueType.ToClassName();
+            }
+        }
+    }
+
+    static class ShaderPortExtensions
+    {
+        public static MaterialSlot GetSlot(this Port port)
+        {
+            var shaderPort = port as ShaderPort;
+            return shaderPort != null ? shaderPort.slot : null;
         }
     }
 }

--- a/MaterialGraphProject/ProjectSettings/ProjectVersion.txt
+++ b/MaterialGraphProject/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.1.0b1
+m_EditorVersion: 2018.1.0b4


### PR DESCRIPTION
# User-facing changes
* Fixes an issue where edges would get detached from their slots and just hang.

# Internal changes
* Introduce a property `MaterialSlot slot` on `ShaderPort`, such that we don't have to access the slot through `userData as MaterialSlot`.
* The `ShaderPort` class now takes care of setting various properties on `Port` based on the given `MaterialSlot`.

# Details
When a topological change is triggered, we used to re-create all the UIElements `Port`s in `MaterialNodeView`. Generally it's not bad to just re-create things, but in this case it meant that the edges, which exists outside the scope of a `MaterialNodeView`, would still refer to the old `Port` and through that the old `MaterialSlot`.

Instead, we now update any `Port`s to the newest data if the `id` of the `MaterialSlot` they were holding on to matches a new `MaterialSlot`. (If the reference still exists we do nothing.) Any `MaterialSlot`s without an existing, matching `Port` has a new one created for it as before.