### PR TITLE
[FIX] Fixed a bug where the master preview didn't update properly after a node got deleted and then undo-ed.

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/PreviewManager.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/PreviewManager.cs
@@ -80,6 +80,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_TimeDependentPreviews.Add(node.tempId.index);
 
             var masterNode = node as IMasterNode;
+
             if (masterRenderData.shaderData == null && masterNode != null)
                 masterRenderData.shaderData = shaderData;
         }
@@ -492,8 +493,9 @@ namespace UnityEditor.ShaderGraph.Drawing
             var renderData = Get(m_RenderDatas, nodeId);
             if (renderData != null)
             {
-                if (masterRenderData != null && masterRenderData.shaderData != null && masterRenderData.shaderData.node == renderData.shaderData.node)
-                    masterRenderData.shaderData = m_RenderDatas.Where(x => x != null && x.shaderData.node is IMasterNode).Select(x => x.shaderData).FirstOrDefault();
+                // Check if we're destroying the shader data used by the master preview
+                if (masterRenderData != null && masterRenderData.shaderData != null && masterRenderData.shaderData == renderData.shaderData)
+                    masterRenderData.shaderData = m_RenderDatas.Where(x => x != null && x.shaderData.node is IMasterNode && x != renderData).Select(x => x.shaderData).FirstOrDefault();
 
                 DestroyRenderData(renderData);
 


### PR DESCRIPTION
# User-facing changes
* Fix a bug where if the user deleted a node or edge and pressed undo, the master preview wouldn't update properly. That is now rectified.
