### PR TITLE
Reflect Experimental API changes in trunk by using pre-processor defines

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Manipulators/GraphDropTarget.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Manipulators/GraphDropTarget.cs
@@ -16,12 +16,22 @@ namespace UnityEditor.ShaderGraph.Drawing
         protected override void RegisterCallbacksOnTarget()
         {
             m_GraphView = target as MaterialGraphView;
+#if UNITY_2018_2_OR_NEWER
+            target.RegisterCallback<DragUpdatedEvent>(OnDragEvent);
+            target.RegisterCallback<DragPerformEvent>(OnDragEvent);
+#else
             target.RegisterCallback<IMGUIEvent>(OnIMGUIEvent);
+#endif
         }
 
         protected override void UnregisterCallbacksFromTarget()
         {
+#if UNITY_2018_2_OR_NEWER
+            target.UnregisterCallback<DragUpdatedEvent>(OnDragEvent);
+            target.UnregisterCallback<DragPerformEvent>(OnDragEvent);
+#else
             target.UnregisterCallback<IMGUIEvent>(OnIMGUIEvent);
+#endif
         }
 
         bool ValidateObject(Object obj)
@@ -88,9 +98,17 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
+#if UNITY_2018_2_OR_NEWER
+        void OnDragEvent(EventBase evt)
+#else
         void OnIMGUIEvent(IMGUIEvent evt)
+#endif
         {
+#if UNITY_2018_2_OR_NEWER
+            if (evt is DragUpdatedEvent || evt is DragPerformEvent)
+#else
             if (evt.imguiEvent.type == EventType.DragUpdated || evt.imguiEvent.type == EventType.DragPerform)
+#endif
             {
                 var currentTarget = evt.currentTarget as VisualElement;
                 if (currentTarget == null)
@@ -110,7 +128,11 @@ namespace UnityEditor.ShaderGraph.Drawing
 
 //                Debug.LogFormat("{0}: {1}", draggedObject.GetType().Name, draggedObject.name);
                 DragAndDrop.visualMode = DragAndDropVisualMode.Generic;
+#if UNITY_2018_2_OR_NEWER
+                if (evt is DragPerformEvent)
+#else
                 if (evt.imguiEvent.type == EventType.DragPerform)
+#endif
                 {
                     var nodePosition = m_GraphView.contentViewContainer.transform.matrix.inverse.MultiplyPoint3x4(m_GraphView.panel.visualTree.ChangeCoordinatesTo(m_GraphView, Event.current.mousePosition));
                     CreateNode(draggedObject, nodePosition);

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Manipulators/WindowDraggable.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Manipulators/WindowDraggable.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Experimental.UIElements;
 using UnityEditor.Experimental.UIElements;
+#if !UNITY_2018_2_OR_NEWER
+using GeometryChangedEvent=UnityEngine.Experimental.UIElements.PostLayoutEvent;
+#endif
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -33,7 +36,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             target.RegisterCallback(new EventCallback<MouseDownEvent>(OnMouseDown), Capture.NoCapture);
             target.RegisterCallback(new EventCallback<MouseMoveEvent>(OnMouseMove), Capture.NoCapture);
             target.RegisterCallback(new EventCallback<MouseUpEvent>(OnMouseUp), Capture.NoCapture);
-            target.RegisterCallback<PostLayoutEvent>(InitialLayoutSetup);
+            target.RegisterCallback<GeometryChangedEvent>(InitialLayoutSetup);
         }
 
         protected override void UnregisterCallbacksFromTarget()
@@ -92,16 +95,16 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_DockTop = windowCenter.y < .5f;
         }
 
-        void InitialLayoutSetup(PostLayoutEvent postLayoutEvent)
+        void InitialLayoutSetup(GeometryChangedEvent postLayoutEvent)
         {
             m_PreviousParentRect = target.parent.layout;
-            target.UnregisterCallback<PostLayoutEvent>(InitialLayoutSetup);
-            target.RegisterCallback<PostLayoutEvent>(OnPostLayout);
+            target.UnregisterCallback<GeometryChangedEvent>(InitialLayoutSetup);
+            target.RegisterCallback<GeometryChangedEvent>(OnPostLayout);
 
             RefreshDocking();
         }
 
-        void OnPostLayout(PostLayoutEvent postLayoutEvent)
+        void OnPostLayout(GeometryChangedEvent postLayoutEvent)
         {
             Rect windowRect = target.layout;
 

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -13,6 +13,9 @@ using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph;
 using Object = UnityEngine.Object;
 using Edge = UnityEditor.Experimental.UIElements.GraphView.Edge;
+#if !UNITY_2018_2_OR_NEWER
+using GeometryChangedEvent=UnityEngine.Experimental.UIElements.PostLayoutEvent;
+#endif
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -434,7 +437,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 graphObject.graph.ValidateGraph();
 
                 graphEditorView = new GraphEditorView(this, m_GraphObject.graph as AbstractMaterialGraph, asset.name) { persistenceKey = selectedGuid };
-                graphEditorView.RegisterCallback<PostLayoutEvent>(OnPostLayout);
+                graphEditorView.RegisterCallback<GeometryChangedEvent>(OnPostLayout);
 
                 titleContent = new GUIContent(asset.name);
 
@@ -449,9 +452,9 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        void OnPostLayout(PostLayoutEvent evt)
+        void OnPostLayout(GeometryChangedEvent evt)
         {
-            graphEditorView.UnregisterCallback<PostLayoutEvent>(OnPostLayout);
+            graphEditorView.UnregisterCallback<GeometryChangedEvent>(OnPostLayout);
             graphEditorView.graphView.FrameAll();
         }
     }

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/GraphEditorView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/GraphEditorView.cs
@@ -8,6 +8,9 @@ using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph.Drawing.Inspector;
 using Edge = UnityEditor.Experimental.UIElements.GraphView.Edge;
 using Object = UnityEngine.Object;
+#if !UNITY_2018_2_OR_NEWER
+using GeometryChangedEvent=UnityEngine.Experimental.UIElements.PostLayoutEvent;
+#endif
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -76,8 +79,8 @@ namespace UnityEditor.ShaderGraph.Drawing
 
                 m_GraphInspectorView = new GraphInspectorView(assetName, previewManager, graph) { name = "inspector" };
                 m_GraphInspectorView.AddManipulator(new Draggable(OnMouseDrag, true));
-                m_GraphView.RegisterCallback<PostLayoutEvent>(OnPostLayout);
-                m_GraphInspectorView.RegisterCallback<PostLayoutEvent>(OnPostLayout);
+                m_GraphView.RegisterCallback<GeometryChangedEvent>(OnPostLayout);
+                m_GraphInspectorView.RegisterCallback<GeometryChangedEvent>(OnPostLayout);
 
                 m_GraphView.RegisterCallback<KeyDownEvent>(OnSpaceDown);
 
@@ -105,7 +108,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             Add(content);
         }
 
-        void OnPostLayout(PostLayoutEvent evt)
+        void OnPostLayout(GeometryChangedEvent evt)
         {
             const float minimumVisibility = 60f;
 
@@ -307,19 +310,19 @@ namespace UnityEditor.ShaderGraph.Drawing
                     var slot = (MaterialSlot)port.userData;
                     if (slot.slotReference.Equals(m_SearchWindowProvider.targetSlotReference))
                     {
-                        port.RegisterCallback<PostLayoutEvent>(RepositionNode);
+                        port.RegisterCallback<GeometryChangedEvent>(RepositionNode);
                         return;
                     }
                 }
             }
         }
 
-        static void RepositionNode(PostLayoutEvent evt)
+        static void RepositionNode(GeometryChangedEvent evt)
         {
             var port = evt.target as ShaderPort;
             if (port == null)
                 return;
-            port.UnregisterCallback<PostLayoutEvent>(RepositionNode);
+            port.UnregisterCallback<GeometryChangedEvent>(RepositionNode);
             var nodeView = port.node as MaterialNodeView;
             if (nodeView == null)
                 return;

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/ShaderPort.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/ShaderPort.cs
@@ -8,7 +8,11 @@ namespace UnityEditor.ShaderGraph.Drawing
     sealed class ShaderPort : Port
     {
         ShaderPort(Orientation portOrientation, Direction portDirection, Type type)
-            : base(portOrientation, portDirection, type) { }
+            : base(portOrientation, portDirection,
+#if UNITY_2018_2_OR_NEWER
+                Capacity.Multi,
+#endif
+                type) { }
 
         public static Port Create(Orientation orientation, Direction direction, Type type, IEdgeConnectorListener connectorListener)
         {


### PR DESCRIPTION
This make ShaderGraph compile with both 2018.1 and trunk.
I _assume_ it's completely transparent in terms of functionality but I'd recommend doing a quick QA pass to make sure feature using the GeometryChangedEvent still function correctly.
There are only subtle changes that shouldn't affect you guys, contact me for more details.

As for the port capacity, "multi" is the behaviour that existed in 2018.1.