### PR TITLE
[FIX] Fixed an issue where openening up an empty shadergraph without …

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/PreviewManager.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/PreviewManager.cs
@@ -487,13 +487,15 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         void DestroyRenderData(PreviewRenderData renderData)
         {
-            if (renderData.shaderData.shader != null && renderData.shaderData.shader != m_UberShader)
+            if (renderData.shaderData != null
+                && renderData.shaderData.shader != null 
+                && renderData.shaderData.shader != m_UberShader)
                 Object.DestroyImmediate(renderData.shaderData.shader, true);
             if (renderData.renderTexture != null)
                 Object.DestroyImmediate(renderData.renderTexture, true);
-            var node = renderData.shaderData.node;
-            if (node != null)
-                node.onModified -= OnNodeModified;
+            
+            if (renderData.shaderData != null && renderData.shaderData.node != null)
+                renderData.shaderData.node.onModified -= OnNodeModified;
         }
 
         void DestroyPreview(Identifier nodeId)

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/GraphEditorView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/GraphEditorView.cs
@@ -459,11 +459,11 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         public void Dispose()
         {
-            saveRequested = null;
-            convertToSubgraphRequested = null;
-            showInProjectRequested = null;
             if (m_GraphView != null)
             {
+                saveRequested = null;
+                convertToSubgraphRequested = null;
+                showInProjectRequested = null;
                 foreach (var node in m_GraphView.Children().OfType<MaterialNodeView>())
                     node.Dispose();
                 m_GraphView = null;


### PR DESCRIPTION
…any nodes caused an error.