### PR TITLE
Fixes & performance improvements

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/GraphEditorView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/GraphEditorView.cs
@@ -93,6 +93,10 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_GraphView.RegisterCallback<KeyDownEvent>(OnSpaceDown);
                 content.Add(m_GraphView);
 
+                // Uncomment to enable pixel caching profiler
+//                m_ProfilerView = new PixelCacheProfilerView(this);
+//                m_GraphView.Add(m_ProfilerView);
+
                 m_BlackboardProvider = new BlackboardProvider(assetName, graph);
                 m_GraphView.Add(m_BlackboardProvider.blackboard);
                 m_BlackboardProvider.blackboard.layout = new Rect(new Vector2(10f, 10f), m_BlackboardProvider.blackboard.layout.size);
@@ -290,6 +294,9 @@ namespace UnityEditor.ShaderGraph.Drawing
                 node.UpdatePortInputVisibilities();
 
             UpdateEdgeColors(nodesToUpdate);
+
+            if (m_ProfilerView != null)
+                m_ProfilerView.Profile();
         }
 
         void AddNode(INode node)
@@ -384,6 +391,7 @@ namespace UnityEditor.ShaderGraph.Drawing
         }
 
         Stack<MaterialNodeView> m_NodeStack = new Stack<MaterialNodeView>();
+        PixelCacheProfilerView m_ProfilerView;
 
         void UpdateEdgeColors(HashSet<MaterialNodeView> nodeViews)
         {

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/MaterialNodeView.cs
@@ -15,7 +15,8 @@ namespace UnityEditor.ShaderGraph.Drawing
     {
         List<VisualElement> m_ControlViews;
         PreviewRenderData m_PreviewRenderData;
-        PreviewTextureView m_PreviewTextureView;
+        Image m_PreviewImage;
+        VisualElement m_PreviewElement;
         VisualElement m_ControlsContainer;
         VisualElement m_PreviewContainer;
         List<Attacher> m_Attachers;
@@ -47,12 +48,19 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_PreviewContainer = new VisualElement { name = "previewContainer" };
                 m_PreviewContainer.AddToClassList("expanded");
                 {
-                    m_PreviewTextureView = new PreviewTextureView
+                    m_PreviewElement = new VisualElement
+                    {
+                        name = "previewElement",
+                        clippingOptions = ClippingOptions.ClipAndCacheContents,
+                        pickingMode = PickingMode.Ignore
+                    };
+                    m_PreviewImage = new Image
                     {
                         name = "preview",
                         pickingMode = PickingMode.Ignore,
-                        image = Texture2D.whiteTexture
+                        image = Texture2D.whiteTexture,
                     };
+                    m_PreviewElement.Add(m_PreviewImage);
                     m_PreviewRenderData = previewManager.GetPreview(inNode);
                     m_PreviewRenderData.onPreviewChanged += UpdatePreviewTexture;
                     UpdatePreviewTexture();
@@ -65,7 +73,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                         UpdatePreviewExpandedState(false);
                     }));
                     UpdatePreviewExpandedState(node.previewExpanded);
-                    m_PreviewTextureView.Add(collapsePreviewButton);
+                    m_PreviewImage.Add(collapsePreviewButton);
 
                     var expandPreviewButton = new VisualElement { name = "expand" };
                     expandPreviewButton.Add(new VisualElement { name = "icon" });
@@ -162,18 +170,18 @@ namespace UnityEditor.ShaderGraph.Drawing
                 return;
             if (expanded)
             {
-                if (m_PreviewTextureView.parent != m_PreviewContainer)
+                if (m_PreviewElement.parent != this)
                 {
-                    m_PreviewContainer.Add(m_PreviewTextureView);
+                    Add(m_PreviewElement);
                 }
                 m_PreviewContainer.AddToClassList("expanded");
                 m_PreviewContainer.RemoveFromClassList("collapsed");
             }
             else
             {
-                if (m_PreviewTextureView.parent == m_PreviewContainer)
+                if (m_PreviewElement.parent == m_PreviewContainer)
                 {
-                    m_PreviewTextureView.RemoveFromHierarchy();
+                    m_PreviewElement.RemoveFromHierarchy();
                 }
                 m_PreviewContainer.RemoveFromClassList("expanded");
                 m_PreviewContainer.AddToClassList("collapsed");
@@ -325,7 +333,7 @@ namespace UnityEditor.ShaderGraph.Drawing
         void OnResize(Vector2 deltaSize)
         {
             var updatedWidth = topContainer.layout.width + deltaSize.x;
-            var updatedHeight = m_PreviewTextureView.layout.height + deltaSize.y;
+            var updatedHeight = m_PreviewImage.layout.height + deltaSize.y;
 
             var previewNode = node as PreviewNode;
             if (previewNode != null)
@@ -339,18 +347,18 @@ namespace UnityEditor.ShaderGraph.Drawing
         {
             if (m_PreviewRenderData.texture == null || !node.previewExpanded)
             {
-                m_PreviewTextureView.visible = false;
-                m_PreviewTextureView.image = Texture2D.blackTexture;
+                m_PreviewImage.visible = false;
+                m_PreviewImage.image = Texture2D.blackTexture;
             }
             else
             {
-                m_PreviewTextureView.visible = true;
-                m_PreviewTextureView.AddToClassList("visible");
-                m_PreviewTextureView.RemoveFromClassList("hidden");
-                if (m_PreviewTextureView.image != m_PreviewRenderData.texture)
-                    m_PreviewTextureView.image = m_PreviewRenderData.texture;
+                m_PreviewImage.visible = true;
+                m_PreviewImage.AddToClassList("visible");
+                m_PreviewImage.RemoveFromClassList("hidden");
+                if (m_PreviewImage.image != m_PreviewRenderData.texture)
+                    m_PreviewImage.image = m_PreviewRenderData.texture;
                 else
-                    m_PreviewTextureView.Dirty(ChangeType.Repaint);
+                    m_PreviewImage.Dirty(ChangeType.Repaint);
             }
         }
 
@@ -387,7 +395,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             var width = previewNode.width;
             var height = previewNode.height;
 
-            m_PreviewTextureView.style.height = height;
+            m_PreviewImage.style.height = height;
         }
 
         public void Dispose()

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/MaterialNodeView.cs
@@ -291,7 +291,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 {
                     var portInputView = new PortInputView(port.slot);
                     Add(portInputView);
-                    mainContainer.BringToFront();
+                    portInputView.SendToBack();
                     m_Attachers.Add(new Attacher(portInputView, port, SpriteAlignment.LeftCenter) { distance = -8f });
                 }
             }

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/PixelCacheProfilerView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/PixelCacheProfilerView.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq;
+using UnityEngine;
+using UnityEngine.Experimental.UIElements;
+
+namespace UnityEditor.ShaderGraph.Drawing
+{
+    public class PixelCacheProfilerView : VisualElement
+    {
+        readonly VisualElement m_Target;
+        Label m_TotalLabel;
+        Label m_DirtyLabel;
+        Label m_TotalNodeContentsLabel;
+        Label m_DirtyNodeContentsLabel;
+        Label m_TotalPreviewsLabel;
+        Label m_DirtyPreviewsLabel;
+        Label m_TotalInlinesLabel;
+        Label m_DirtyInlinesLabel;
+
+        public PixelCacheProfilerView(VisualElement target)
+        {
+            m_Target = target;
+
+            var tpl = Resources.Load<VisualTreeAsset>("UXML/PixelCacheProfiler");
+            tpl.CloneTree(this, null);
+
+            m_TotalLabel = this.Q<Label>("totalLabel");
+            m_DirtyLabel = this.Q<Label>("dirtyLabel");
+            m_TotalNodeContentsLabel = this.Q<Label>("totalNodeContentsLabel");
+            m_DirtyNodeContentsLabel = this.Q<Label>("dirtyNodeContentsLabel");
+            m_TotalPreviewsLabel = this.Q<Label>("totalPreviewsLabel");
+            m_DirtyPreviewsLabel = this.Q<Label>("dirtyPreviewsLabel");
+            m_TotalInlinesLabel = this.Q<Label>("totalInlinesLabel");
+            m_DirtyInlinesLabel = this.Q<Label>("dirtyInlinesLabel");
+        }
+
+        public void Profile()
+        {
+            var caches = m_Target.Query().Where(ve => ve.clippingOptions == ClippingOptions.ClipAndCacheContents).Build().ToList();
+            var dirtyCaches = caches.Where(ve => ve.IsDirty(ChangeType.Repaint)).ToList();
+            m_TotalLabel.text = caches.Count.ToString();
+            m_DirtyLabel.text = dirtyCaches.Count.ToString();
+
+            var nodeContentsCaches = caches.Where(ve => ve.name == "node-border").ToList();
+            var dirtyNodeContentsCaches = nodeContentsCaches.Where(ve => ve.IsDirty(ChangeType.Repaint)).ToList();
+            m_TotalNodeContentsLabel.text = nodeContentsCaches.Count.ToString();
+            m_DirtyNodeContentsLabel.text = dirtyNodeContentsCaches.Count.ToString();
+
+            var previewCaches = caches.Where(ve => ve.name == "previewContainer").ToList();
+            var dirtyPreviewCaches = previewCaches.Where(ve => ve.IsDirty(ChangeType.Repaint)).ToList();
+            m_TotalPreviewsLabel.text = previewCaches.Count.ToString();
+            m_DirtyPreviewsLabel.text = dirtyPreviewCaches.Count.ToString();
+
+            var inlineCaches = caches.Where(ve => ve.name == "portInputContainer").ToList();
+            var dirtyInlineCaches = inlineCaches.Where(ve => ve.IsDirty(ChangeType.Repaint)).ToList();
+            m_TotalInlinesLabel.text = inlineCaches.Count.ToString();
+            m_DirtyInlinesLabel.text = dirtyInlineCaches.Count.ToString();
+        }
+    }
+}

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/PixelCacheProfilerView.cs.meta
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/PixelCacheProfilerView.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7147f25b12dd4427b4c8afd44624f35b
+timeCreated: 1517227822

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/PortInputView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/PortInputView.cs
@@ -19,6 +19,11 @@ namespace UnityEditor.ShaderGraph.Drawing
             get { return m_EdgeColor.GetSpecifiedValueOrDefault(Color.red); }
         }
 
+        public MaterialSlot slot
+        {
+            get { return m_Slot; }
+        }
+
         MaterialSlot m_Slot;
         ConcreteSlotValueType m_SlotType;
         VisualElement m_Control;
@@ -44,7 +49,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             m_Container = new VisualElement { name = "container" };
             {
-                m_Control = m_Slot.InstantiateControl();
+                m_Control = this.slot.InstantiateControl();
                 if (m_Control != null)
                     m_Container.Add(m_Control);
 
@@ -57,7 +62,6 @@ namespace UnityEditor.ShaderGraph.Drawing
             Add(m_Container);
 
             m_Container.visible = m_EdgeControl.visible = m_Control != null;
-            m_Container.clippingOptions = ClippingOptions.ClipAndCacheContents;
         }
 
         protected override void OnStyleResolved(ICustomStyle styles)
@@ -71,10 +75,10 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         public void UpdateSlotType()
         {
-            if (m_Slot.concreteValueType != m_SlotType)
+            if (slot.concreteValueType != m_SlotType)
             {
                 RemoveFromClassList("type" + m_SlotType);
-                m_SlotType = m_Slot.concreteValueType;
+                m_SlotType = slot.concreteValueType;
                 AddToClassList("type" + m_SlotType);
                 if (m_Control != null)
                 {
@@ -83,7 +87,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                         disposable.Dispose();
                     m_Container.Remove(m_Control);
                 }
-                m_Control = m_Slot.InstantiateControl();
+                m_Control = slot.InstantiateControl();
                 if (m_Control != null)
                     m_Container.Insert(0, m_Control);
 

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/Styles/MaterialGraph.uss
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/Styles/MaterialGraph.uss
@@ -32,22 +32,27 @@ MaterialNodeView.graphElement.node.MaterialNode {
     margin-right: 0;
 }
 
-MaterialNodeView #previewContainer.expanded {
-    width: 200;
-    height: 200;
+MaterialNodeView #collapsible-area {
+    width: 0;
+    height: 0;
 }
 
-MaterialNodeView #previewContainer,
+MaterialNodeView #previewFiller.expanded {
+    width: 200;
+    padding-bottom: 200;
+}
+
+MaterialNodeView #previewFiller,
 MaterialNodeView #controls {
     background-color: rgba(63, 63, 63, 0.8);
 }
 
-MaterialNodeView #controls.notEmpty {
+MaterialNodeView #controls > #items {
     padding-top: 4;
     padding-bottom: 4;
 }
 
-MaterialNodeView > #previewElement {
+MaterialNodeView > #previewContainer {
     position-type: absolute;
     position-bottom: 4;
     position-left: 4;
@@ -55,13 +60,13 @@ MaterialNodeView > #previewElement {
     padding-top: 6;
 }
 
-MaterialNodeView > #previewElement > #preview  {
+MaterialNodeView > #previewContainer > #preview  {
     width: 200;
     height: 200;
     align-items:center;
 }
 
-MaterialNodeView > #previewElement > #preview > #collapse {
+MaterialNodeView > #previewContainer > #preview > #collapse {
     background-color: #000;
     border-color: #F0F0F0;
     width: 0;
@@ -78,23 +83,23 @@ MaterialNodeView > #previewElement > #preview > #collapse {
 }
 
 
-MaterialNodeView:hover > #previewElement > #preview > #collapse {
+MaterialNodeView:hover > #previewContainer > #preview > #collapse {
     width: 20;
     height: 20;
     opacity: 0.6;
 }
 
-MaterialNodeView > #previewElement > #preview > #collapse > #icon  {
+MaterialNodeView > #previewContainer > #preview > #collapse > #icon  {
     background-image : resource("GraphView/Nodes/PreviewCollapse.png");
     width: 16;
     height: 16;
 }
 
-MaterialNodeView > #previewElement > #preview > #collapse:hover {
+MaterialNodeView > #previewContainer > #preview > #collapse:hover {
     opacity: 1.0;
 }
 
-MaterialNodeView #previewContainer > #expand {
+MaterialNodeView #previewFiller > #expand {
     align-self: center;
     width: 56;
     height: 16;
@@ -102,18 +107,18 @@ MaterialNodeView #previewContainer > #expand {
     justify-content:center;
 }
 
-MaterialNodeView #previewContainer > #expand > #icon {
+MaterialNodeView #previewFiller > #expand > #icon {
     align-self: center;
     background-image : resource("GraphView/Nodes/PreviewExpand.png");
     width: 16;
     height: 16;
 }
 
-MaterialNodeView #previewContainer.collapsed > #expand:hover {
+MaterialNodeView #previewFiller.collapsed > #expand:hover {
     background-color: #2B2B2B;
 }
 
-MaterialNodeView #previewContainer.expanded > #expand {
+MaterialNodeView #previewFiller.expanded > #expand {
     height: 0;
 }
 
@@ -125,6 +130,13 @@ MaterialNodeView > #resize {
     width: 10;
     height: 10;
     cursor: resize-up-left;
+}
+
+MaterialNodeView > #portInputContainer {
+    position-type: absolute;
+    width: 212;
+    position-left: -200;
+    position-top: 46;
 }
 
 PortInputView {

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/Styles/MaterialGraph.uss
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/Styles/MaterialGraph.uss
@@ -32,6 +32,11 @@ MaterialNodeView.graphElement.node.MaterialNode {
     margin-right: 0;
 }
 
+MaterialNodeView #previewContainer.expanded {
+    width: 200;
+    height: 200;
+}
+
 MaterialNodeView #previewContainer,
 MaterialNodeView #controls {
     background-color: rgba(63, 63, 63, 0.8);
@@ -42,13 +47,21 @@ MaterialNodeView #controls.notEmpty {
     padding-bottom: 4;
 }
 
-MaterialNodeView #previewContainer > #preview  {
+MaterialNodeView > #previewElement {
+    position-type: absolute;
+    position-bottom: 4;
+    position-left: 4;
+    border-radius: 6;
+    padding-top: 6;
+}
+
+MaterialNodeView > #previewElement > #preview  {
     width: 200;
     height: 200;
     align-items:center;
 }
 
-MaterialNodeView #previewContainer > #preview > #collapse {
+MaterialNodeView > #previewElement > #preview > #collapse {
     background-color: #000;
     border-color: #F0F0F0;
     width: 0;
@@ -65,24 +78,20 @@ MaterialNodeView #previewContainer > #preview > #collapse {
 }
 
 
-MaterialNodeView #previewContainer:hover > #preview > #collapse {
+MaterialNodeView:hover > #previewElement > #preview > #collapse {
     width: 20;
     height: 20;
     opacity: 0.6;
 }
 
-MaterialNodeView #previewContainer > #preview > #collapse > #icon
-{
+MaterialNodeView > #previewElement > #preview > #collapse > #icon  {
     background-image : resource("GraphView/Nodes/PreviewCollapse.png");
     width: 16;
     height: 16;
 }
-MaterialNodeView #previewContainer > #preview > #collapse:hover {
-    opacity: 1.0;
-}
 
-MaterialNodeView #previewContainer.collapsed > #preview > #collapse {
-    height: 0;
+MaterialNodeView > #previewElement > #preview > #collapse:hover {
+    opacity: 1.0;
 }
 
 MaterialNodeView #previewContainer > #expand {

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/Styles/PixelCacheProfiler.uss
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/Styles/PixelCacheProfiler.uss
@@ -1,0 +1,11 @@
+PixelCacheProfilerView > #content > #title {
+    font-style: bold;
+}
+
+PixelCacheProfilerView > #content > .row {
+    flex-direction: row;
+}
+
+PixelCacheProfilerView > #content > .indented {
+    padding-left: 8;
+}

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/Styles/PixelCacheProfiler.uss.meta
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/Styles/PixelCacheProfiler.uss.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 61cf67e9c1f54ceab08d2bd16ffd3c53
+ScriptedImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/UXML/PixelCacheProfiler.uxml
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/UXML/PixelCacheProfiler.uxml
@@ -1,0 +1,39 @@
+<UXML xmlns:ui="UnityEngine.Experimental.UIElements">
+    <ui:VisualElement name="content">
+        <Style path="Styles/PixelCacheProfiler"/>
+        <ui:Label name="title" text="Pixel Cache Profiler"/>
+        <ui:VisualElement class="row">
+            <ui:Label text="Total pixel caches: "/>
+            <ui:Label name="totalLabel" text="-"/>
+        </ui:VisualElement>
+        <ui:VisualElement class="indented row">
+            <ui:Label text="Node contents: "/>
+            <ui:Label name="totalNodeContentsLabel" text="-"/>
+        </ui:VisualElement>
+        <ui:VisualElement class="indented row">
+            <ui:Label text="Node previews: "/>
+            <ui:Label name="totalPreviewsLabel" text="-"/>
+        </ui:VisualElement>
+        <ui:VisualElement class="indented row">
+            <ui:Label text="Inline inputs: "/>
+            <ui:Label name="totalInlinesLabel" text="-"/>
+        </ui:VisualElement>
+
+        <ui:VisualElement class="row">
+            <ui:Label text="Dirty pixel caches: "/>
+            <ui:Label name="dirtyLabel" text="-"/>
+        </ui:VisualElement>
+        <ui:VisualElement class="indented row">
+            <ui:Label text="Node contents: "/>
+            <ui:Label name="dirtyNodeContentsLabel" text="-"/>
+        </ui:VisualElement>
+        <ui:VisualElement class="indented row">
+            <ui:Label text="Node previews: "/>
+            <ui:Label name="dirtyPreviewsLabel" text="-"/>
+        </ui:VisualElement>
+        <ui:VisualElement class="indented row">
+            <ui:Label text="Inline inputs: "/>
+            <ui:Label name="dirtyInlinesLabel" text="-"/>
+        </ui:VisualElement>
+    </ui:VisualElement>
+</UXML>

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/UXML/PixelCacheProfiler.uxml.meta
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/UXML/PixelCacheProfiler.uxml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0fda1aff5a5744478f70542e95fd3d42
+ScriptedImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
# User-facing changes
* UI rendering time reduced by roughly half
* Fix bug causing selection outlines to disappear when zoomed out
* Collapsing a node no longer affects controls and preview

# Details
There were 2 major culprits wrt. performance. The first was the fact that updating the preview texture would dirty the entire node. This has been fixed by putting the actual texture in its own pixel cached element which floats above the node. The second culprit was the inline inputs, which were being dirtied every frame by the `Attacher`. These have been put into a shared, pixel-cached element per node and the `Attacher` class is no longer used. 

In order to track down the pixel cached elements being dirtied each frame, I wrote a small profiler UI which per frame counts the number of pixel cached elements, how many of them were dirty that frame and divides those 2 numbers into a few categories. This UI can be enabled by uncommenting a few lines of code.

I've made the change to the expanded/collapsed behavior first and foremost because the preview has its own collapse state. I included the controls in this change because the node collapse button is disabled based only on whether all the connections of the node are filled out. Thus, previously, if all connections were filled out you wouldn't be able to collapse the controls. Furthermore I feel that the controls display vital information that should not be hidden.