### PR TITLE
Small fixes to "Open Documentation" menu item.

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/MaterialGraphView.cs
@@ -57,8 +57,11 @@ namespace UnityEditor.ShaderGraph.Drawing
                 evt.menu.AppendAction("Convert To Sub-graph", ConvertToSubgraph, ConvertToSubgraphStatus);
                 evt.menu.AppendAction("Convert To Inline Node", ConvertToInlineNode, ConvertToInlineNodeStatus);
                 evt.menu.AppendAction("Convert To Property", ConvertToProperty, ConvertToPropertyStatus);
-                evt.menu.AppendSeparator();
-                evt.menu.AppendAction("Open Documentation", SeeDocumentation, SeeDocumentationStatus);
+                if (selection.OfType<MaterialNodeView>().Count() == 1)
+                {
+                    evt.menu.AppendSeparator();
+                    evt.menu.AppendAction("Open Documentation", SeeDocumentation, SeeDocumentationStatus);
+                }
             }
             else if (evt.target is BlackboardField)
             {
@@ -99,8 +102,6 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         ContextualMenu.MenuAction.StatusFlags SeeDocumentationStatus(EventBase eventBase)
         {
-            if (selection.OfType<MaterialNodeView>().Count() > 1)
-                return ContextualMenu.MenuAction.StatusFlags.Hidden;
             if (selection.OfType<MaterialNodeView>().First().node.documentationURL == null)
                 return ContextualMenu.MenuAction.StatusFlags.Disabled;
             return ContextualMenu.MenuAction.StatusFlags.Normal;


### PR DESCRIPTION
- Fixed an issue causing InvalidOperationException when opening the right-click menu without having a selected node. Now it shows "Open Documentation" menu item only when a single node is selected.
- Changed not to show the separator when the menu item is hidden.