### PR TITLE
Improvements to RandomRangeNode

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Math/Range/RandomRangeNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Math/Range/RandomRangeNode.cs
@@ -1,3 +1,4 @@
+using UnityEngine;
 using System.Reflection;
 
 namespace UnityEditor.ShaderGraph
@@ -16,7 +17,7 @@ namespace UnityEditor.ShaderGraph
         }
 
         static string Unity_RandomRange(
-            [Slot(0, Binding.None)] Vector1 Seed,
+            [Slot(0, Binding.None)] Vector2 Seed,
             [Slot(1, Binding.None)] Vector1 Min,
             [Slot(2, Binding.None, 1, 1, 1, 1)] Vector1 Max,
             [Slot(3, Binding.None)] out Vector1 Out)
@@ -24,8 +25,8 @@ namespace UnityEditor.ShaderGraph
             return
                 @"
 {
-     {precision} randomno =  frac(sin(dot({precision}2(Seed, Seed), float2(12.9898, 78.233)))*43758.5453);
-     Out = floor(randomno * (Max - Min + 1)) + Min;
+     {precision} randomno =  frac(sin(dot(Seed, float2(12.9898, 78.233)))*43758.5453);
+     Out = lerp(Min, Max, randomno);
 }";
         }
     }


### PR DESCRIPTION
- Changed the seed input type from Vector1 to Vector2. This makes it handy to generate random noise texture from UV.
- Changed how min/max is applied to random numbers. Although I'm not sure what the original intention was, I think simply lerping from min to max is more natural implementation.