### PR TITLE
Clear node selection when deleting nodes.

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/MaterialGraphView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/MaterialGraphView.cs
@@ -250,6 +250,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                     graph.RemoveShaderProperty(property.guid);
                 }
             }
+            selection.Clear();
         }
 
         public bool CanAcceptDrop(List<ISelectable> selection)


### PR DESCRIPTION
There was an issue that the selection list was not cleared on deletion of nodes. This caused several problems when invoking node-editing actions right after deletion.

e.g. Delete a random node and then open the right click menu without selecting anything. This causes InvalidOperationException in BuildContextualMenu.

This small fix changes the behavior to clear the selection list in the end of the deletion function.