### PR TITLE
Improvements to artistic nodes.

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Adjustment/ReplaceColorNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Adjustment/ReplaceColorNode.cs
@@ -21,17 +21,15 @@ namespace UnityEditor.ShaderGraph
             [Slot(1, Binding.None)] ColorRGB From,
             [Slot(2, Binding.None)] ColorRGB To,
             [Slot(3, Binding.None)] Vector1 Range,
-            [Slot(4, Binding.None)] out Vector3 Out)
+            [Slot(4, Binding.None)] Vector1 Fuzziness,
+            [Slot(5, Binding.None)] out Vector3 Out)
         {
-            Out = Vector2.zero;
+            Out = Vector3.zero;
             return
                 @"
 {
-    {precision}3 col = In;
     {precision} Distance = distance(From, In);
-    if(Distance <= Range)
-        col = To;
-    Out = col;
+    Out = lerp(To, In, saturate((Distance - Range) / max(Fuzziness, 1e-5f)));
 }";
         }
     }

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Adjustment/ReplaceColorNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Adjustment/ReplaceColorNode.cs
@@ -21,8 +21,8 @@ namespace UnityEditor.ShaderGraph
             [Slot(1, Binding.None)] ColorRGB From,
             [Slot(2, Binding.None)] ColorRGB To,
             [Slot(3, Binding.None)] Vector1 Range,
-            [Slot(4, Binding.None)] Vector1 Fuzziness,
-            [Slot(5, Binding.None)] out Vector3 Out)
+            [Slot(5, Binding.None)] Vector1 Fuzziness,
+            [Slot(4, Binding.None)] out Vector3 Out)
         {
             Out = Vector3.zero;
             return

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Blend/BlendNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Blend/BlendNode.cs
@@ -44,8 +44,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Burn(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -58,8 +58,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Darken(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -72,8 +72,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Difference(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -86,8 +86,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Dodge(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -100,8 +100,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Divide(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -114,8 +114,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Exclusion(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -128,15 +128,15 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_HardLight(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}{slot3dimension} result1 = 1.0 - 2.0 * (1.0 - Base) * (1.0 - Blend);
-    {precision}{slot3dimension} result2 = 2.0 * Base * Blend;
-    {precision}{slot3dimension} zeroOrOne = step(Blend, 0.5);
+    {precision}{slot2dimension} result1 = 1.0 - 2.0 * (1.0 - Base) * (1.0 - Blend);
+    {precision}{slot2dimension} result2 = 2.0 * Base * Blend;
+    {precision}{slot2dimension} zeroOrOne = step(Blend, 0.5);
     Out = result2 * zeroOrOne + (1 - zeroOrOne) * result1;
     Out = lerp(Base, Out, Opacity);
 }";
@@ -145,8 +145,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_HardMix(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -159,8 +159,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Lighten(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -173,8 +173,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_LinearBurn(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -187,8 +187,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_LinearDodge(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -201,8 +201,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_LinearLight(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -215,8 +215,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_LinearLightAddSub(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -229,8 +229,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Multiply(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -243,8 +243,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Negation(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -257,8 +257,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Screen(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
@@ -271,15 +271,15 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Overlay(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}{slot3dimension} result1 = 1.0 - 2.0 * (1.0 - Base) * (1.0 - Blend);
-    {precision}{slot3dimension} result2 = 2.0 * Base * Blend;
-    {precision}{slot3dimension} zeroOrOne = step(Base, 0.5);
+    {precision}{slot2dimension} result1 = 1.0 - 2.0 * (1.0 - Base) * (1.0 - Blend);
+    {precision}{slot2dimension} result2 = 2.0 * Base * Blend;
+    {precision}{slot2dimension} zeroOrOne = step(Base, 0.5);
     Out = result2 * zeroOrOne + (1 - zeroOrOne) * result1;
     Out = lerp(Base, Out, Opacity);
 }
@@ -289,14 +289,14 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_PinLight(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}{slot3dimension} check = step (0.5, Blend);
-    {precision}{slot3dimension} result1 = check * max(2.0 * (Base - 0.5), Blend);
+    {precision}{slot2dimension} check = step (0.5, Blend);
+    {precision}{slot2dimension} result1 = check * max(2.0 * (Base - 0.5), Blend);
     Out = result1 + (1.0 - check) * min(2.0 * Base, Blend);
     Out = lerp(Base, Out, Opacity);
 }
@@ -306,15 +306,15 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_SoftLight(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}{slot3dimension} result1 = 2.0 * Base * Blend + Base * Base * (1.0 - 2.0 * Blend);
-    {precision}{slot3dimension} result2 = sqrt(Base) * (2.0 * Blend - 1.0) + 2.0 * Base * (1.0 - Blend);
-    {precision}{slot3dimension} zeroOrOne = step(0.5, Blend);
+    {precision}{slot2dimension} result1 = 2.0 * Base * Blend + Base * Base * (1.0 - 2.0 * Blend);
+    {precision}{slot2dimension} result2 = sqrt(Base) * (2.0 * Blend - 1.0) + 2.0 * Base * (1.0 - Blend);
+    {precision}{slot2dimension} zeroOrOne = step(0.5, Blend);
     Out = result2 * zeroOrOne + (1 - zeroOrOne) * result1;
     Out = lerp(Base, Out, Opacity);
 }
@@ -324,15 +324,15 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_VividLight(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}{slot3dimension} result1 = 1.0 - (1.0 - Blend) / (2.0 * Base);
-    {precision}{slot3dimension} result2 = Blend / (2.0 * (1.0 - Base));
-    {precision}{slot3dimension} zeroOrOne = step(0.5, Base);
+    {precision}{slot2dimension} result1 = 1.0 - (1.0 - Blend) / (2.0 * Base);
+    {precision}{slot2dimension} result2 = Blend / (2.0 * (1.0 - Base));
+    {precision}{slot2dimension} zeroOrOne = step(0.5, Base);
     Out = result2 * zeroOrOne + (1 - zeroOrOne) * result1;
     Out = lerp(Base, Out, Opacity);
 }
@@ -342,8 +342,8 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Subtract(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] Vector1 Opacity,
-            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(3, Binding.None, 1, 1, 1, 1)] Vector1 Opacity,
+            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Blend/BlendNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Blend/BlendNode.cs
@@ -44,210 +44,244 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Burn(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out =  1.0 - (1.0 - Blend)/Base;
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_Darken(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = min(Blend, Base);
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_Difference(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = abs(Blend - Base);
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_Dodge(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = Base / (1.0 - Blend);
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_Divide(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = Base / (Blend + 0.000000000001);
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_Exclusion(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = Blend + Base - (2.0 * Blend * Base);
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_HardLight(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}{slot2dimension} result1 = 1.0 - 2.0 * (1.0 - Base) * (1.0 - Blend);
-    {precision}{slot2dimension} result2 = 2.0 * Base * Blend;
-    {precision}{slot2dimension} zeroOrOne = step(Blend, 0.5);
+    {precision}{slot3dimension} result1 = 1.0 - 2.0 * (1.0 - Base) * (1.0 - Blend);
+    {precision}{slot3dimension} result2 = 2.0 * Base * Blend;
+    {precision}{slot3dimension} zeroOrOne = step(Blend, 0.5);
     Out = result2 * zeroOrOne + (1 - zeroOrOne) * result1;
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_HardMix(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = step(1 - Base, Blend);
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_Lighten(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = max(Blend, Base);
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_LinearBurn(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = Base + Blend - 1.0;
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_LinearDodge(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = Base + Blend;
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_LinearLight(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = Blend < 0.5 ? max(Base + (2 * Blend) - 1, 0) : min(Base + 2 * (Blend - 0.5), 1);
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_LinearLightAddSub(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = Blend + 2.0 * Base - 1.0;
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_Multiply(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = Base * Blend;
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_Negation(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = 1.0 - abs(1.0 - Blend - Base);
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_Screen(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = 1.0 - (1.0 - Blend) * (1.0 - Base);
+    Out = lerp(Base, Out, Opacity);
 }";
         }
 
         static string Unity_Blend_Overlay(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}{slot2dimension} result1 = 1.0 - 2.0 * (1.0 - Base) * (1.0 - Blend);
-    {precision}{slot2dimension} result2 = 2.0 * Base * Blend;
-    {precision}{slot2dimension} zeroOrOne = step(Base, 0.5);
+    {precision}{slot3dimension} result1 = 1.0 - 2.0 * (1.0 - Base) * (1.0 - Blend);
+    {precision}{slot3dimension} result2 = 2.0 * Base * Blend;
+    {precision}{slot3dimension} zeroOrOne = step(Base, 0.5);
     Out = result2 * zeroOrOne + (1 - zeroOrOne) * result1;
+    Out = lerp(Base, Out, Opacity);
 }
 ";
         }
@@ -255,14 +289,16 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_PinLight(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}{slot2dimension} check = step (0.5, Blend);
-    {precision}{slot2dimension} result1 = check * max(2.0 * (Base - 0.5), Blend);
+    {precision}{slot3dimension} check = step (0.5, Blend);
+    {precision}{slot3dimension} result1 = check * max(2.0 * (Base - 0.5), Blend);
     Out = result1 + (1.0 - check) * min(2.0 * Base, Blend);
+    Out = lerp(Base, Out, Opacity);
 }
 ";
         }
@@ -270,15 +306,17 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_SoftLight(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}{slot2dimension} result1 = 2.0 * Base * Blend + Base * Base * (1.0 - 2.0 * Blend);
-    {precision}{slot2dimension} result2 = sqrt(Base) * (2.0 * Blend - 1.0) + 2.0 * Base * (1.0 - Blend);
-    {precision}{slot2dimension} zeroOrOne = step(0.5, Blend);
+    {precision}{slot3dimension} result1 = 2.0 * Base * Blend + Base * Base * (1.0 - 2.0 * Blend);
+    {precision}{slot3dimension} result2 = sqrt(Base) * (2.0 * Blend - 1.0) + 2.0 * Base * (1.0 - Blend);
+    {precision}{slot3dimension} zeroOrOne = step(0.5, Blend);
     Out = result2 * zeroOrOne + (1 - zeroOrOne) * result1;
+    Out = lerp(Base, Out, Opacity);
 }
 ";
         }
@@ -286,15 +324,17 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_VividLight(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}{slot2dimension} result1 = 1.0 - (1.0 - Blend) / (2.0 * Base);
-    {precision}{slot2dimension} result2 = Blend / (2.0 * (1.0 - Base));
-    {precision}{slot2dimension} zeroOrOne = step(0.5, Base);
+    {precision}{slot3dimension} result1 = 1.0 - (1.0 - Blend) / (2.0 * Base);
+    {precision}{slot3dimension} result2 = Blend / (2.0 * (1.0 - Base));
+    {precision}{slot3dimension} zeroOrOne = step(0.5, Base);
     Out = result2 * zeroOrOne + (1 - zeroOrOne) * result1;
+    Out = lerp(Base, Out, Opacity);
 }
 ";
         }
@@ -302,12 +342,14 @@ namespace UnityEditor.ShaderGraph
         static string Unity_Blend_Subtract(
             [Slot(0, Binding.None)] DynamicDimensionVector Base,
             [Slot(1, Binding.None)] DynamicDimensionVector Blend,
-            [Slot(2, Binding.None)] out DynamicDimensionVector Out)
+            [Slot(2, Binding.None)] Vector1 Opacity,
+            [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
     Out = Base - Blend;
+    Out = lerp(Base, Out, Opacity);
 }
 ";
         }

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Mask/ColorMaskNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Mask/ColorMaskNode.cs
@@ -20,8 +20,8 @@ namespace UnityEditor.ShaderGraph
             [Slot(0, Binding.None)] Vector3 In,
             [Slot(1, Binding.None)] ColorRGB MaskColor,
             [Slot(2, Binding.None)] Vector1 Range,
-            [Slot(3, Binding.None)] Vector1 Fuzziness,
-            [Slot(4, Binding.None)] out Vector1 Out)
+            [Slot(4, Binding.None)] Vector1 Fuzziness,
+            [Slot(3, Binding.None)] out Vector1 Out)
         {
             return
                 @"

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Mask/ColorMaskNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Mask/ColorMaskNode.cs
@@ -20,17 +20,14 @@ namespace UnityEditor.ShaderGraph
             [Slot(0, Binding.None)] Vector3 In,
             [Slot(1, Binding.None)] ColorRGB MaskColor,
             [Slot(2, Binding.None)] Vector1 Range,
-            [Slot(3, Binding.None)] out Vector3 Out)
+            [Slot(3, Binding.None)] Vector1 Fuzziness,
+            [Slot(4, Binding.None)] out Vector1 Out)
         {
-            Out = Vector3.zero;
             return
                 @"
 {
-    {precision}3 col = {precision}3(0, 0, 0);
     {precision} Distance = distance(MaskColor, In);
-    if(Distance <= Range)
-        col = {precision}3(1, 1, 1);
-    Out = col;
+    Out = saturate(1 - (Distance - Range) / max(Fuzziness, 1e-5));
 }";
         }
     }


### PR DESCRIPTION
- Added the Fuzziness slot to ReplaceColorNode and ColorMaskNode. It works like the fuzziness parameter in Photoshop that gives softer edges to the mask.

![comparison](https://i.imgur.com/cNO6XNt.png)

- Changed the output format of ColorMaskNode from Vector3 to Vector1. It only outputs single channel masks.
- Added the Opacity slot to BlendNode. It's useful when one tries using BlendNode like layers in Photoshop.