### PR TITLE
Addition of Gradient Noise node.

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Procedural/Noise/GradientNoiseNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Procedural/Noise/GradientNoiseNode.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using UnityEngine;
+
+namespace UnityEditor.ShaderGraph
+{
+    [Title("Procedural", "Noise", "Gradient Noise")]
+    public class GradientNoiseNode : CodeFunctionNode
+    {
+        public GradientNoiseNode()
+        {
+            name = "Gradient Noise";
+        }
+
+        protected override MethodInfo GetFunctionToConvert()
+        {
+            return GetType().GetMethod("Unity_GradientNoise", BindingFlags.Static | BindingFlags.NonPublic);
+        }
+
+        static string Unity_GradientNoise(
+            [Slot(0, Binding.MeshUV0)] Vector2 UV,
+            [Slot(1, Binding.None, 10, 10, 10, 10)] Vector1 Scale,
+            [Slot(2, Binding.None)] out Vector1 Out)
+        {
+            return "{ Out = unity_gradientNoise(UV * Scale) + 0.5; }";
+        }
+
+        public override void GenerateNodeFunction(FunctionRegistry registry, GenerationMode generationMode)
+        {
+            registry.ProvideFunction("unity_gradientNoise_dir", s => s.Append(@"
+float2 unity_gradientNoise_dir(float2 p)
+{
+    // Permutation and hashing used in webgl-nosie goo.gl/pX7HtC
+    p = p % 289;
+    float x = (34 * p.x + 1) * p.x % 289 + p.y;
+    x = (34 * x + 1) * x % 289;
+    x = frac(x / 41) * 2 - 1;
+    return normalize(float2(x - floor(x + 0.5), abs(x) - 0.5));
+}
+"));
+
+            registry.ProvideFunction("unity_gradientNoise", s => s.Append(@"
+float unity_gradientNoise(float2 p)
+{
+    float2 ip = floor(p);
+    float2 fp = frac(p);
+    float d00 = dot(unity_gradientNoise_dir(ip), fp);
+    float d01 = dot(unity_gradientNoise_dir(ip + float2(0, 1)), fp - float2(0, 1));
+    float d10 = dot(unity_gradientNoise_dir(ip + float2(1, 0)), fp - float2(1, 0));
+    float d11 = dot(unity_gradientNoise_dir(ip + float2(1, 1)), fp - float2(1, 1));
+    fp = fp * fp * fp * (fp * (fp * 6 - 15) + 10);
+    return lerp(lerp(d00, d01, fp.y), lerp(d10, d11, fp.y), fp.x);
+}
+"));
+
+            base.GenerateNodeFunction(registry, generationMode);
+        }
+    }
+}

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Procedural/Noise/GradientNoiseNode.cs.meta
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Procedural/Noise/GradientNoiseNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8e5f34a7e7cbfe4a9444e42ccfc7ea4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request is to add GradientNoiseNode that generates 2D gradient noise (generally called "Perlin noise").

![gradient noise](https://i.imgur.com/mpftbhX.png)

Gradient noise is widely used in several DCC software tools to generate procedural textures/animations. Note that it has different characteristics from value noise (used in SimpleNoiseNode). Adding it to the basic node library is thought to be important when we try to make ShaderGraph compatible with commonly-used procedural techniques.