### PR TITLE
Addition of ScreenPositionSlotControlView

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Graphs/ScreenPositionMaterialSlot.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Graphs/ScreenPositionMaterialSlot.cs
@@ -1,28 +1,53 @@
 using System;
 using UnityEditor.Graphing;
+using UnityEditor.ShaderGraph.Drawing.Slots;
 using UnityEngine;
+using UnityEngine.Experimental.UIElements;
 
 namespace UnityEditor.ShaderGraph
 {
     [Serializable]
     public class ScreenPositionMaterialSlot : Vector4MaterialSlot, IMayRequireScreenPosition
     {
+        [SerializeField]
+        ScreenSpaceType m_ScreenSpaceType;
+
+        public ScreenSpaceType screenSpaceType
+        {
+            get { return m_ScreenSpaceType; }
+            set { m_ScreenSpaceType = value; }
+        }
+
         public ScreenPositionMaterialSlot()
         {}
 
-        public ScreenPositionMaterialSlot(int slotId, string displayName, string shaderOutputName,
+        public ScreenPositionMaterialSlot(int slotId, string displayName, string shaderOutputName, ScreenSpaceType screenSpaceType,
                                           ShaderStage shaderStage = ShaderStage.Dynamic, bool hidden = false)
             : base(slotId, displayName, shaderOutputName, SlotType.Input, Vector3.zero, shaderStage, hidden)
-        {}
+        {
+            this.screenSpaceType = screenSpaceType;
+        }
+
+        public override VisualElement InstantiateControl()
+        {
+            return new ScreenPositionSlotControlView(this);
+        }
 
         public override string GetDefaultValue(GenerationMode generationMode)
         {
-            return string.Format("IN.{0}", ShaderGeneratorNames.ScreenPosition);
+            return m_ScreenSpaceType.ToValueAsVariable();
         }
 
         public bool RequiresScreenPosition()
         {
             return !isConnected;
+        }
+
+        public override void CopyValuesFrom(MaterialSlot foundSlot)
+        {
+            var slot = foundSlot as ScreenPositionMaterialSlot;
+            if (slot != null)
+                screenSpaceType = slot.screenSpaceType;
         }
     }
 }

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Filter/DitherNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Artistic/Filter/DitherNode.cs
@@ -17,13 +17,13 @@ namespace UnityEditor.ShaderGraph
         }
         static string Unity_Dither(
             [Slot(0, Binding.None)] DynamicDimensionVector In,
-            [Slot(1, Binding.ScreenPosition)] Vector2 UV,
+            [Slot(1, Binding.ScreenPosition)] Vector2 ScreenPosition,
             [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    {precision}2 uv = (UV.xy / UV.w) * _ScreenParams.xy;
+    {precision}2 uv = ScreenPosition.xy * _ScreenParams.xy;
     {precision} DITHER_THRESHOLDS[16] =
     {
         1.0 / 17.0,  9.0 / 17.0,  3.0 / 17.0, 11.0 / 17.0,

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/CodeFunctionNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/CodeFunctionNode.cs
@@ -274,7 +274,7 @@ namespace UnityEditor.ShaderGraph
                 case Binding.MeshUV3:
                     return new UVMaterialSlot(slotId, displayName, shaderOutputName, UVChannel.UV3);
                 case Binding.ScreenPosition:
-                    return new ScreenPositionMaterialSlot(slotId, displayName, shaderOutputName);
+                    return new ScreenPositionMaterialSlot(slotId, displayName, shaderOutputName, ScreenSpaceType.Default);
                 case Binding.ObjectSpaceViewDirection:
                     return new ViewDirectionMaterialSlot(slotId, displayName, shaderOutputName, CoordinateSpace.Object);
                 case Binding.ViewSpaceViewDirection:

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Input/Geometry/ScreenPositionNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Input/Geometry/ScreenPositionNode.cs
@@ -5,14 +5,6 @@ using UnityEditor.ShaderGraph.Drawing.Controls;
 
 namespace UnityEditor.ShaderGraph
 {
-    public enum ScreenSpaceType
-    {
-        Default,
-        Raw,
-        Center,
-        Tiled
-    };
-
     [Title("Input", "Geometry", "Screen Position")]
     public class ScreenPositionNode : AbstractMaterialNode, IGeneratesBodyCode, IMayRequireScreenPosition
     {
@@ -57,27 +49,7 @@ namespace UnityEditor.ShaderGraph
 
         public void GenerateNodeCode(ShaderGenerator visitor, GenerationMode generationMode)
         {
-            switch (m_ScreenSpaceType)
-            {
-                case ScreenSpaceType.Raw:
-                    visitor.AddShaderChunk(string.Format("{0}4 {1} = IN.{2};", precision, GetVariableNameForSlot(kOutputSlotId),
-                        ShaderGeneratorNames.ScreenPosition), true);
-                    break;
-                case ScreenSpaceType.Center:
-                    visitor.AddShaderChunk(string.Format("{0}4 {1} = {2};", precision, GetVariableNameForSlot(kOutputSlotId),
-                        string.Format("float4((IN.{0}.xy / IN.{0}.w) * 2 - 1, 0, 0)", ShaderGeneratorNames.ScreenPosition)), true);
-                    break;
-                case ScreenSpaceType.Tiled:
-                    visitor.AddShaderChunk(string.Format("{0}4 {1} = {2};", precision, GetVariableNameForSlot(kOutputSlotId),
-                        string.Format("float4((IN.{0}.xy / IN.{0}.w) * 2 - 1, 0, 0)", ShaderGeneratorNames.ScreenPosition)), true);
-                    visitor.AddShaderChunk(string.Format("{0} = {1};", GetVariableNameForSlot(kOutputSlotId),
-                        string.Format("frac(float4({0}.x * _ScreenParams.x / _ScreenParams.y, {0}.y, 0, 0))", GetVariableNameForSlot(kOutputSlotId))), true);
-                    break;
-                default:
-                    visitor.AddShaderChunk(string.Format("{0}4 {1} = {2};", precision, GetVariableNameForSlot(kOutputSlotId),
-                        string.Format("float4(IN.{0}.xy / IN.{0}.w, 0, 0)", ShaderGeneratorNames.ScreenPosition)), true);
-                    break;
-            }
+            visitor.AddShaderChunk(string.Format("{0}4 {1} = {2};", precision, GetVariableNameForSlot(kOutputSlotId), m_ScreenSpaceType.ToValueAsVariable()), true);
         }
 
         public bool RequiresScreenPosition()

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Util/ScreenSpaceType.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Util/ScreenSpaceType.cs
@@ -1,0 +1,28 @@
+namespace UnityEditor.ShaderGraph
+{
+    public enum ScreenSpaceType
+    {
+        Default,
+        Raw,
+        Center,
+        Tiled
+    };
+
+    public static class ScreenSpaceTypeExtensions
+    {
+        public static string ToValueAsVariable(this ScreenSpaceType screenSpaceType)
+        {
+            switch (screenSpaceType)
+            {
+                case ScreenSpaceType.Raw:
+                    return string.Format("IN.{0}", ShaderGeneratorNames.ScreenPosition);
+                case ScreenSpaceType.Center:
+                    return string.Format("float4(IN.{0}.xy / IN.{0}.w * 2 - 1, 0, 0)", ShaderGeneratorNames.ScreenPosition);
+                case ScreenSpaceType.Tiled:
+                    return string.Format("frac(float4((IN.{0}.x / IN.{0}.w * 2 - 1) * _ScreenParams.x / _ScreenParams.y, IN.{0}.y / IN.{0}.w * 2 - 1, 0, 0))", ShaderGeneratorNames.ScreenPosition);
+                default:
+                    return string.Format("float4(IN.{0}.xy / IN.{0}.w, 0, 0)", ShaderGeneratorNames.ScreenPosition);
+            }
+        }
+    }
+}

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Util/ScreenSpaceType.cs.meta
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Util/ScreenSpaceType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d296e8d1103ed5c49a267d57be0f4d96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/Slots/ScreenPositionSlotControlView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/Slots/ScreenPositionSlotControlView.cs
@@ -1,0 +1,31 @@
+using System;
+using UnityEditor.Graphing;
+using UnityEditor.Experimental.UIElements;
+using UnityEngine.Experimental.UIElements;
+
+namespace UnityEditor.ShaderGraph.Drawing.Slots
+{
+    public class ScreenPositionSlotControlView : VisualElement
+    {
+        ScreenPositionMaterialSlot m_Slot;
+
+        public ScreenPositionSlotControlView(ScreenPositionMaterialSlot slot)
+        {
+            m_Slot = slot;
+            var enumField = new EnumField(slot.screenSpaceType);
+            enumField.OnValueChanged(OnValueChanged);
+            Add(enumField);
+        }
+
+        void OnValueChanged(ChangeEvent<Enum> evt)
+        {
+            var screenSpaceType = (ScreenSpaceType)evt.newValue;
+            if (screenSpaceType != m_Slot.screenSpaceType)
+            {
+                m_Slot.owner.owner.owner.RegisterCompleteObjectUndo("Change Screen Space Type");
+                m_Slot.screenSpaceType = screenSpaceType;
+                m_Slot.owner.Dirty(ModificationScope.Graph);
+            }
+        }
+    }
+}

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/Slots/ScreenPositionSlotControlView.cs.meta
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/Slots/ScreenPositionSlotControlView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1774f54355319894888ab5ec90b728e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/Styles/MaterialGraph.uss
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Resources/Styles/MaterialGraph.uss
@@ -296,6 +296,14 @@ UVSlotControlView > EnumField {
     width: 40;
 }
 
+ScreenPositionSlotControlView > EnumField {
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: 0;
+    margin-right: 0;
+    width: 54;
+}
+
 ColorRGBASlotControlView {
     flex-direction: row;
     align-items: center;


### PR DESCRIPTION
In the current version of Shader Graph, there is no custom control view for screen position slots, so users can't simply distinguish them from vector4 slots.

By providing the custom view for the screen position slots, it becomes clear that these slots have different functionalities from simple Vector4 slots or UV slots. It also allows selecting one of the screen space types from the drop down list. This is convenient when using screen space dependent filters like DitherNode.

![slot view](https://i.imgur.com/fuzk9Wb.png)
(UI comparison, left: before / right: after)

**Changes made in this PR**

- Added ScreenPositionSlotControlView and its style element (USS).
- Moved ScreenSpaceType enum definition to ScreenSpaceType.cs and added ScreenSpaceTypeExtensions that provides extension methods for the enum.
- Updated the existing implementation to work with ScreenPositionSlotControlView.