### PR TITLE
Safer callbacks

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Interfaces/Graph/INode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Interfaces/Graph/INode.cs
@@ -16,7 +16,8 @@ namespace UnityEditor.Graphing
 
     public interface INode
     {
-        OnNodeModified onModified { get; set; }
+        void RegisterCallback(OnNodeModified callback);
+        void UnregisterCallback(OnNodeModified callback);
         void Dirty(ModificationScope scope);
         IGraph owner { get; set; }
         Guid guid { get; }

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/AbstractMaterialNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/AbstractMaterialNode.cs
@@ -44,12 +44,22 @@ namespace UnityEditor.ShaderGraph
 
         public IGraph owner { get; set; }
 
-        public OnNodeModified onModified { get; set; }
+        OnNodeModified m_OnModified;
+
+        public void RegisterCallback(OnNodeModified callback)
+        {
+            m_OnModified += callback;
+        }
+
+        public void UnregisterCallback(OnNodeModified callback)
+        {
+            m_OnModified -= callback;
+        }
 
         public void Dirty(ModificationScope scope)
         {
-            if (onModified != null)
-                onModified(this, scope);
+            if (m_OnModified != null)
+                m_OnModified(this, scope);
         }
 
         public Guid guid

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/PreviewManager.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/PreviewManager.cs
@@ -75,7 +75,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             Set(m_Identifiers, node.tempId, node.tempId);
             Set(m_RenderDatas, node.tempId, renderData);
             m_DirtyShaders.Add(node.tempId.index);
-            node.onModified += OnNodeModified;
+            node.RegisterCallback(OnNodeModified);
             if (node.RequiresTime())
                 m_TimeDependentPreviews.Add(node.tempId.index);
 
@@ -495,7 +495,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 Object.DestroyImmediate(renderData.renderTexture, true);
 
             if (renderData.shaderData != null && renderData.shaderData.node != null)
-                renderData.shaderData.node.onModified -= OnNodeModified;
+                renderData.shaderData.node.UnregisterCallback(OnNodeModified);
         }
 
         void DestroyPreview(Identifier nodeId)

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/GraphEditorView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Views/GraphEditorView.cs
@@ -256,7 +256,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             foreach (var node in m_Graph.removedNodes)
             {
-                node.onModified -= OnNodeChanged;
+                node.UnregisterCallback(OnNodeChanged);
                 var nodeView = m_GraphView.nodes.ToList().OfType<MaterialNodeView>().FirstOrDefault(p => p.node != null && p.node.guid == node.guid);
                 if (nodeView != null)
                 {
@@ -313,7 +313,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             var nodeView = new MaterialNodeView { userData = node };
             m_GraphView.AddElement(nodeView);
             nodeView.Initialize(node as AbstractMaterialNode, m_PreviewManager, m_EdgeConnectorListener);
-            node.onModified += OnNodeChanged;
+            node.RegisterCallback(OnNodeChanged);
             nodeView.Dirty(ChangeType.Repaint);
 
             if (m_SearchWindowProvider.nodeNeedsRepositioning && m_SearchWindowProvider.targetSlotReference.nodeGuid.Equals(node.guid))


### PR DESCRIPTION
* Replace `onNodeModified` with methods for registering and deregistering to avoid direct access to the delegate.

The reason for this is that calling the delegate directly requires you to check for null, which is easy to forget. Earlier a method `Dirty(ModificationScope)` was added to alleviate this, but `onNodeModified` was still accessible. `Dirty(ModificationScope)` will do the check and is also much more convenient to call:
`if (node.onModified != null) node.onModified(node, ModificationScope.Node)`
vs
`node.Dirty(ModificationScope.Node)`