### PR TITLE
Easy-to-understand slot names for Step node.

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Math/Interpolation/SmoothstepNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Math/Interpolation/SmoothstepNode.cs
@@ -21,15 +21,15 @@ namespace UnityEditor.ShaderGraph
         }
 
         static string Unity_Smoothstep(
-            [Slot(0, Binding.None, 0, 0, 0, 0)] DynamicDimensionVector A,
-            [Slot(1, Binding.None, 1, 1, 1, 1)] DynamicDimensionVector B,
-            [Slot(2, Binding.None, 0, 0, 0, 0)] DynamicDimensionVector T,
+            [Slot(0, Binding.None, 0, 0, 0, 0)] DynamicDimensionVector Edge1,
+            [Slot(1, Binding.None, 1, 1, 1, 1)] DynamicDimensionVector Edge2,
+            [Slot(2, Binding.None, 0, 0, 0, 0)] DynamicDimensionVector In,
             [Slot(3, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    Out = smoothstep(A, B, T);
+    Out = smoothstep(Edge1, Edge2, In);
 }";
         }
     }

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Math/Round/StepNode.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Data/Nodes/Math/Round/StepNode.cs
@@ -17,14 +17,14 @@ namespace UnityEditor.ShaderGraph
         }
 
         static string Unity_Step(
-            [Slot(0, Binding.None, 1, 1, 1, 1)] DynamicDimensionVector A,
-            [Slot(1, Binding.None, 0, 0, 0, 0)] DynamicDimensionVector B,
+            [Slot(0, Binding.None, 1, 1, 1, 1)] DynamicDimensionVector Edge,
+            [Slot(1, Binding.None, 0, 0, 0, 0)] DynamicDimensionVector In,
             [Slot(2, Binding.None)] out DynamicDimensionVector Out)
         {
             return
                 @"
 {
-    Out = step(A, B);
+    Out = step(Edge, In);
 }
 ";
         }


### PR DESCRIPTION
The slot names of the Step node are difficult to understand what they're for.

![before](https://i.imgur.com/tTjFjYq.png)

This pull request suggests more easy-to-understand names, following [the GLSL terminology](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/step.xhtml)

![after](https://i.imgur.com/hDJoKao.png)

Also the slot names of the SmoothStep node are changed.