### PR TITLE
Fix for NullReferenceException in master preview.

### DIFF
--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Inspector/MasterPreviewView.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/Inspector/MasterPreviewView.cs
@@ -80,7 +80,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector
 
         IMasterNode masterNode
         {
-            get { return m_PreviewRenderHandle.shaderData.node as IMasterNode; }
+            get { return m_PreviewRenderHandle.shaderData != null ? m_PreviewRenderHandle.shaderData.node as IMasterNode : null; }
         }
 
         void DirtyMasterNode(ModificationScope scope)

--- a/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/PreviewManager.cs
+++ b/MaterialGraphProject/Assets/UnityShaderEditor/Editor/Drawing/PreviewManager.cs
@@ -61,7 +61,8 @@ namespace UnityEditor.ShaderGraph.Drawing
         public void ResizeMasterPreview(Vector2 newSize)
         {
             m_NewMasterPreviewSize = newSize;
-            m_DirtyPreviews.Add(masterRenderData.shaderData.node.tempId.index);
+            if (masterRenderData.shaderData != null)
+                m_DirtyPreviews.Add(masterRenderData.shaderData.node.tempId.index);
         }
 
         public PreviewRenderData GetPreview(AbstractMaterialNode node)


### PR DESCRIPTION
From 2b1bbd8be76c86db5e26f2e65229d4191c47968e, the master preview causes NullReferenceException with the following situations.

- Opening a sub-graph (this is considered to be a showstopper issue).
- Deleting all master nodes from a graph.

This pull request is to fix the problem by adding null check to some points.