### PR TITLE
Antialiasing with procedural shapes.

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Shape/EllipseNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Shape/EllipseNode.cs
@@ -25,9 +25,8 @@ namespace UnityEditor.ShaderGraph
             return
                 @"
 {
-    UV = (UV * 2.0 - 1.0);
-    UV = UV / {precision}2(Width, Height);
-    Out = step(length(UV), 1);
+    {precision} d = length((UV * 2 - 1) / {precision}2(Width, Height));
+    Out = saturate((1 - d) / fwidth(d));
 }";
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Shape/PolygonNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Shape/PolygonNode.cs
@@ -32,8 +32,7 @@ namespace UnityEditor.ShaderGraph
     {precision} pCoord = atan2(uv.x, uv.y);
     {precision} r = tau / Sides;
     {precision} distance = cos(floor(0.5 + pCoord / r) * r - pCoord) * length(uv);
-    {precision} value = 1 - step(1, smoothstep(0, 1, distance));
-    Out = value;
+    Out = saturate((1 - distance) / fwidth(distance));
 }
 ";
         }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Shape/RectangleNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Shape/RectangleNode.cs
@@ -25,11 +25,9 @@ namespace UnityEditor.ShaderGraph
             return
                 @"
 {
-    {precision}2 XMinAndMax = {precision}2(0.5 - Width / 2, 0.5 + Width / 2);
-    {precision}2 YMinAndMax = {precision}2(0.5 - Height / 2, 0.5 + Height / 2);
-    {precision} x = step( XMinAndMax.x, UV.x ) - step( XMinAndMax.y, UV.x );
-    {precision} y = step( YMinAndMax.x, UV.y ) - step( YMinAndMax.y, UV.y );
-    Out = x * y;
+    {precision}2 d = abs(UV * 2 - 1) - {precision}2(Width, Height);
+    d = 1 - d / fwidth(d);
+    Out = saturate(min(d.x, d.y));
 }";
         }
     }

--- a/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Shape/RoundedRectangleNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Procedural/Shape/RoundedRectangleNode.cs
@@ -26,16 +26,10 @@ namespace UnityEditor.ShaderGraph
             return
                 @"
 {
-    Radius = min(abs(Radius), 0.5 * min(abs(Width), abs(Height)));
-    {precision}2 XMinAndMax = {precision}2(0.5 - abs(Width) / 2, 0.5 + abs(Width) / 2);
-    {precision}2 YMinAndMax = {precision}2(0.5 - abs(Height) / 2, 0.5 + abs(Height) / 2);
-    {precision} wide = (step( XMinAndMax.x, UV.x ) - step( XMinAndMax.y, UV.x )) * (step( YMinAndMax.x + Radius, UV.y ) - step( YMinAndMax.y - Radius, UV.y ));
-    {precision} tall = (step( XMinAndMax.x + Radius, UV.x ) - step( XMinAndMax.y - Radius, UV.x )) * (step( YMinAndMax.x, UV.y ) - step( YMinAndMax.y, UV.y ));
-    {precision} sw = step(length(UV - {precision}2(XMinAndMax.x + Radius, YMinAndMax.x + Radius)), Radius);
-    {precision} se = step(length(UV - {precision}2(XMinAndMax.y - Radius, YMinAndMax.x + Radius)), Radius);
-    {precision} nw = step(length(UV - {precision}2(XMinAndMax.x + Radius, YMinAndMax.y - Radius)), Radius);
-    {precision} ne = step(length(UV - {precision}2(XMinAndMax.y - Radius, YMinAndMax.y - Radius)), Radius);
-    Out = saturate(wide + tall + sw + se + nw + ne);
+    Radius = max(min(min(abs(Radius * 2), abs(Width)), abs(Height)), 1e-5);
+    {precision}2 uv = abs(UV * 2 - 1) - {precision}2(Width, Height) + Radius;
+    {precision} d = length(max(0, uv)) / Radius;
+    Out = saturate((1 - d) / fwidth(d));
 }";
         }
     }


### PR DESCRIPTION
The current implementation of the procedural shape nodes uses the step function to determine the area of the shapes. It causes jaggies (aliasing) on the edges.

![screenshot](https://i.imgur.com/0lGyPpI.png)

These jaggies become more noticeable when using MSAA because these pixel shader-based shapes can't get antialiasing effect from MSAA.

![screenshot](https://i.imgur.com/ttqAMdl.png)

This pull request is to fix the problem by smoothing the edges with using the derivatives (fwidth).

![screenshot](https://i.imgur.com/YvPSLOP.png)

![screenshot](https://i.imgur.com/sIFaJjP.png)