### PR TITLE
Master node improvements

### DIFF
--- a/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightPBRSubShader.cs
+++ b/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightPBRSubShader.cs
@@ -209,7 +209,7 @@ namespace UnityEditor.ShaderGraph
             subShader.Indent();
             subShader.AddShaderChunk("Tags{ \"RenderPipeline\" = \"LightweightPipeline\"}", true);
 
-            var materialOptions = ShaderGenerator.GetMaterialOptionsFromAlphaMode(masterNode.alphaMode);
+            var materialOptions = ShaderGenerator.GetMaterialOptions(masterNode.alphaMode, masterNode.twoSided.isOn);
             var tagsVisitor = new ShaderGenerator();
             materialOptions.GetTags(tagsVisitor);
             subShader.AddShaderChunk(tagsVisitor.GetShaderString(0), true);

--- a/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightPBRSubShader.cs
+++ b/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightPBRSubShader.cs
@@ -173,7 +173,7 @@ namespace UnityEditor.ShaderGraph
             if (masterNode.IsSlotConnected(PBRMasterNode.AlphaThresholdSlotId))
                 defines.AddShaderChunk("#define _AlphaClip 1", true);
 
-            if(masterNode.alphaMode == AlphaMode.Transparent)
+            if(masterNode.surfaceType == SurfaceType.Transparent && masterNode.alphaMode == AlphaMode.Premultiply)
                 defines.AddShaderChunk("#define _ALPHAPREMULTIPLY_ON 1", true);
 
             var templateLocation = ShaderGenerator.GetTemplatePath(template);
@@ -212,7 +212,7 @@ namespace UnityEditor.ShaderGraph
             subShader.Indent();
             subShader.AddShaderChunk("Tags{ \"RenderPipeline\" = \"LightweightPipeline\"}", true);
 
-            var materialOptions = ShaderGenerator.GetMaterialOptions(masterNode.alphaMode, masterNode.twoSided.isOn);
+            var materialOptions = ShaderGenerator.GetMaterialOptions(masterNode.surfaceType, masterNode.alphaMode, masterNode.twoSided.isOn);
             var tagsVisitor = new ShaderGenerator();
             materialOptions.GetTags(tagsVisitor);
             subShader.AddShaderChunk(tagsVisitor.GetShaderString(0), true);

--- a/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightPBRSubShader.cs
+++ b/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightPBRSubShader.cs
@@ -173,6 +173,9 @@ namespace UnityEditor.ShaderGraph
             if (masterNode.IsSlotConnected(PBRMasterNode.AlphaThresholdSlotId))
                 defines.AddShaderChunk("#define _AlphaClip 1", true);
 
+            if(masterNode.alphaMode == AlphaMode.Transparent)
+                defines.AddShaderChunk("#define _ALPHAPREMULTIPLY_ON 1", true);
+
             var templateLocation = ShaderGenerator.GetTemplatePath(template);
 
             foreach (var slot in usedSlots)

--- a/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightPBRSubShader.cs
+++ b/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightPBRSubShader.cs
@@ -228,7 +228,11 @@ namespace UnityEditor.ShaderGraph
 
             var extraPassesTemplateLocation = ShaderGenerator.GetTemplatePath("lightweightPBRExtraPasses.template");
             if (File.Exists(extraPassesTemplateLocation))
-                subShader.AddShaderChunk(File.ReadAllText(extraPassesTemplateLocation), true);
+            {
+                var extraPassesTemplate = File.ReadAllText(extraPassesTemplateLocation);
+                extraPassesTemplate = extraPassesTemplate.Replace("${Culling}", materialOptions.cullMode.ToString());
+                subShader.AddShaderChunk(extraPassesTemplate, true);
+            }            
 
             subShader.Deindent();
             subShader.AddShaderChunk("}", true);

--- a/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightUnlitSubShader.cs
+++ b/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightUnlitSubShader.cs
@@ -206,8 +206,11 @@ namespace UnityEditor.ShaderGraph
 
             var extraPassesTemplateLocation = ShaderGenerator.GetTemplatePath("lightweightUnlitExtraPasses.template");
             if (File.Exists(extraPassesTemplateLocation))
-                subShader.AddShaderChunk(File.ReadAllText(extraPassesTemplateLocation), true);
-
+            {
+                var extraPassesTemplate = File.ReadAllText(extraPassesTemplateLocation);
+                extraPassesTemplate = extraPassesTemplate.Replace("${Culling}", materialOptions.cullMode.ToString());
+                subShader.AddShaderChunk(extraPassesTemplate, true);
+            }
 
             subShader.Deindent();
             subShader.AddShaderChunk("}", true);

--- a/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightUnlitSubShader.cs
+++ b/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightUnlitSubShader.cs
@@ -149,6 +149,9 @@ namespace UnityEditor.ShaderGraph
             if (masterNode.IsSlotConnected(UnlitMasterNode.AlphaThresholdSlotId))
                 defines.AddShaderChunk("#define _AlphaClip 1", true);
 
+            if(masterNode.alphaMode == AlphaMode.Transparent)
+                defines.AddShaderChunk("#define _ALPHAPREMULTIPLY_ON 1", true);
+
             var templateLocation = ShaderGenerator.GetTemplatePath(template);
 
             foreach (var slot in usedSlots)

--- a/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightUnlitSubShader.cs
+++ b/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightUnlitSubShader.cs
@@ -187,7 +187,7 @@ namespace UnityEditor.ShaderGraph
             subShader.Indent();
             subShader.AddShaderChunk("Tags{ \"RenderType\" = \"Opaque\" \"RenderPipeline\" = \"LightweightPipeline\"}", true);
 
-            var materialOptions = ShaderGenerator.GetMaterialOptionsFromAlphaMode(masterNode.alphaMode);
+            var materialOptions = ShaderGenerator.GetMaterialOptions(masterNode.alphaMode, masterNode.twoSided.isOn);
             var tagsVisitor = new ShaderGenerator();
             materialOptions.GetTags(tagsVisitor);
             subShader.AddShaderChunk(tagsVisitor.GetShaderString(0), true);

--- a/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightUnlitSubShader.cs
+++ b/com.unity.shadergraph/Editor/Data/LightweightPipeline/LightWeightUnlitSubShader.cs
@@ -149,7 +149,7 @@ namespace UnityEditor.ShaderGraph
             if (masterNode.IsSlotConnected(UnlitMasterNode.AlphaThresholdSlotId))
                 defines.AddShaderChunk("#define _AlphaClip 1", true);
 
-            if(masterNode.alphaMode == AlphaMode.Transparent)
+            if(masterNode.surfaceType == SurfaceType.Transparent && masterNode.alphaMode == AlphaMode.Premultiply)
                 defines.AddShaderChunk("#define _ALPHAPREMULTIPLY_ON 1", true);
 
             var templateLocation = ShaderGenerator.GetTemplatePath(template);
@@ -190,7 +190,7 @@ namespace UnityEditor.ShaderGraph
             subShader.Indent();
             subShader.AddShaderChunk("Tags{ \"RenderType\" = \"Opaque\" \"RenderPipeline\" = \"LightweightPipeline\"}", true);
 
-            var materialOptions = ShaderGenerator.GetMaterialOptions(masterNode.alphaMode, masterNode.twoSided.isOn);
+            var materialOptions = ShaderGenerator.GetMaterialOptions(masterNode.surfaceType, masterNode.alphaMode, masterNode.twoSided.isOn);
             var tagsVisitor = new ShaderGenerator();
             materialOptions.GetTags(tagsVisitor);
             subShader.AddShaderChunk(tagsVisitor.GetShaderString(0), true);

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/AlphaMode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/AlphaMode.cs
@@ -5,6 +5,7 @@ namespace UnityEditor.ShaderGraph {
     {
         Opaque,
         Fade,
+        Transparent,
         Additive,
         Multiply
     }

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/AlphaMode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/AlphaMode.cs
@@ -4,7 +4,8 @@ namespace UnityEditor.ShaderGraph {
     public enum AlphaMode
     {
         Opaque,
-        AlphaBlend,
-        AdditiveBlend
+        Fade,
+        Additive,
+        Multiply
     }
 }

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/AlphaMode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/AlphaMode.cs
@@ -1,11 +1,17 @@
 using System;
 
-namespace UnityEditor.ShaderGraph {
-    public enum AlphaMode
+namespace UnityEditor.ShaderGraph
+{
+    public enum SurfaceType
     {
         Opaque,
-        Fade,
-        Transparent,
+        Transparent
+    }
+
+    public enum AlphaMode
+    {
+        Alpha,
+        Premultiply,
         Additive,
         Multiply
     }

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/PBRMasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/PBRMasterNode.cs
@@ -56,9 +56,26 @@ namespace UnityEditor.ShaderGraph
         }
 
         [SerializeField]
+        private SurfaceType m_SurfaceType;
+
+        [EnumControl("Surface")]
+        public SurfaceType surfaceType
+        {
+            get { return m_SurfaceType; }
+            set
+            {
+                if (m_SurfaceType == value)
+                    return;
+
+                m_SurfaceType = value;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        [SerializeField]
         private AlphaMode m_AlphaMode;
 
-        [EnumControl("Blending")]
+        [EnumControl("Blend")]
         public AlphaMode alphaMode
         {
             get { return m_AlphaMode; }

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/PBRMasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/PBRMasterNode.cs
@@ -40,7 +40,7 @@ namespace UnityEditor.ShaderGraph
         [SerializeField]
         private Model m_Model = Model.Metallic;
 
-        [EnumControl("")]
+        [EnumControl("Workflow")]
         public Model model
         {
             get { return m_Model; }
@@ -58,7 +58,7 @@ namespace UnityEditor.ShaderGraph
         [SerializeField]
         private AlphaMode m_AlphaMode;
 
-        [EnumControl("")]
+        [EnumControl("Blending")]
         public AlphaMode alphaMode
         {
             get { return m_AlphaMode; }
@@ -68,6 +68,22 @@ namespace UnityEditor.ShaderGraph
                     return;
 
                 m_AlphaMode = value;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        [SerializeField]
+        private bool m_TwoSided;
+
+        [ToggleControl("Two Sided")]
+        public Toggle twoSided
+        {
+            get { return new Toggle(m_TwoSided); }
+            set
+            {
+                if (m_TwoSided == value.isOn)
+                    return;
+                m_TwoSided = value.isOn;
                 Dirty(ModificationScope.Graph);
             }
         }

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/UnlitMasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/UnlitMasterNode.cs
@@ -23,7 +23,7 @@ namespace UnityEditor.ShaderGraph
         [SerializeField]
         private AlphaMode m_AlphaMode;
 
-        [EnumControl("")]
+        [EnumControl("Blending")]
         public AlphaMode alphaMode
         {
             get { return m_AlphaMode; }
@@ -33,6 +33,22 @@ namespace UnityEditor.ShaderGraph
                     return;
 
                 m_AlphaMode = value;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        [SerializeField]
+        private bool m_TwoSided;
+
+        [ToggleControl("Two Sided")]
+        public Toggle twoSided
+        {
+            get { return new Toggle(m_TwoSided); }
+            set
+            {
+                if (m_TwoSided == value.isOn)
+                    return;
+                m_TwoSided = value.isOn;
                 Dirty(ModificationScope.Graph);
             }
         }

--- a/com.unity.shadergraph/Editor/Data/MasterNodes/UnlitMasterNode.cs
+++ b/com.unity.shadergraph/Editor/Data/MasterNodes/UnlitMasterNode.cs
@@ -21,9 +21,26 @@ namespace UnityEditor.ShaderGraph
 
        
         [SerializeField]
+        private SurfaceType m_SurfaceType;
+
+        [EnumControl("Surface")]
+        public SurfaceType surfaceType
+        {
+            get { return m_SurfaceType; }
+            set
+            {
+                if (m_SurfaceType == value)
+                    return;
+
+                m_SurfaceType = value;
+                Dirty(ModificationScope.Graph);
+            }
+        }
+
+        [SerializeField]
         private AlphaMode m_AlphaMode;
 
-        [EnumControl("Blending")]
+        [EnumControl("Blend")]
         public AlphaMode alphaMode
         {
             get { return m_AlphaMode; }

--- a/com.unity.shadergraph/Editor/Data/Util/ShaderGenerator.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/ShaderGenerator.cs
@@ -651,7 +651,7 @@ namespace UnityEditor.ShaderGraph
             return res;
         }
 
-        public static SurfaceMaterialOptions GetMaterialOptionsFromAlphaMode(AlphaMode alphaMode)
+        public static SurfaceMaterialOptions GetMaterialOptions(AlphaMode alphaMode, bool twoSided)
         {
             var materialOptions = new SurfaceMaterialOptions();
             switch (alphaMode)
@@ -659,25 +659,34 @@ namespace UnityEditor.ShaderGraph
                 case AlphaMode.Opaque:
                     materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.One;
                     materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.Zero;
-                    materialOptions.cullMode = SurfaceMaterialOptions.CullMode.Back;
+                    materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
                     materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
                     materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.On;
                     materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Geometry;
                     materialOptions.renderType = SurfaceMaterialOptions.RenderType.Opaque;
                     break;
-                case AlphaMode.AlphaBlend:
+                case AlphaMode.Fade:
                     materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.SrcAlpha;
                     materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.OneMinusSrcAlpha;
-                    materialOptions.cullMode = SurfaceMaterialOptions.CullMode.Back;
+                    materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
                     materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
                     materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
                     materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
                     materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
                     break;
-                case AlphaMode.AdditiveBlend:
+                case AlphaMode.Additive:
                     materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.One;
                     materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.One;
-                    materialOptions.cullMode = SurfaceMaterialOptions.CullMode.Back;
+                    materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
+                    materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
+                    materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
+                    materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
+                    materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
+                    break;
+                case AlphaMode.Multiply:
+                    materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.DstColor;
+                    materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.Zero;
+                    materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
                     materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
                     materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
                     materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;

--- a/com.unity.shadergraph/Editor/Data/Util/ShaderGenerator.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/ShaderGenerator.cs
@@ -651,12 +651,12 @@ namespace UnityEditor.ShaderGraph
             return res;
         }
 
-        public static SurfaceMaterialOptions GetMaterialOptions(AlphaMode alphaMode, bool twoSided)
+        public static SurfaceMaterialOptions GetMaterialOptions(SurfaceType surfaceType, AlphaMode alphaMode, bool twoSided)
         {
             var materialOptions = new SurfaceMaterialOptions();
-            switch (alphaMode)
+            switch (surfaceType)
             {
-                case AlphaMode.Opaque:
+                case SurfaceType.Opaque:
                     materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.One;
                     materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.Zero;
                     materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
@@ -665,43 +665,49 @@ namespace UnityEditor.ShaderGraph
                     materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Geometry;
                     materialOptions.renderType = SurfaceMaterialOptions.RenderType.Opaque;
                     break;
-                case AlphaMode.Fade:
-                    materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.SrcAlpha;
-                    materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.OneMinusSrcAlpha;
-                    materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
-                    materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
-                    materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
-                    materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
-                    materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
-                    break;
-                case AlphaMode.Transparent:
-                    materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.One;
-                    materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.OneMinusSrcAlpha;
-                    materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
-                    materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
-                    materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
-                    materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
-                    materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
-                    break;
-                case AlphaMode.Additive:
-                    materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.One;
-                    materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.One;
-                    materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
-                    materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
-                    materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
-                    materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
-                    materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
-                    break;
-                case AlphaMode.Multiply:
-                    materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.DstColor;
-                    materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.Zero;
-                    materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
-                    materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
-                    materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
-                    materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
-                    materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
+                case SurfaceType.Transparent:
+                    switch (alphaMode)
+                    {
+                        case AlphaMode.Alpha:
+                            materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.SrcAlpha;
+                            materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.OneMinusSrcAlpha;
+                            materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
+                            materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
+                            materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
+                            materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
+                            materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
+                            break;
+                        case AlphaMode.Premultiply:
+                            materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.One;
+                            materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.OneMinusSrcAlpha;
+                            materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
+                            materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
+                            materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
+                            materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
+                            materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
+                            break;
+                        case AlphaMode.Additive:
+                            materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.One;
+                            materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.One;
+                            materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
+                            materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
+                            materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
+                            materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
+                            materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
+                            break;
+                        case AlphaMode.Multiply:
+                            materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.DstColor;
+                            materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.Zero;
+                            materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
+                            materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
+                            materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
+                            materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
+                            materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
+                            break;
+                    }
                     break;
             }
+            
             return materialOptions;
         }
 

--- a/com.unity.shadergraph/Editor/Data/Util/ShaderGenerator.cs
+++ b/com.unity.shadergraph/Editor/Data/Util/ShaderGenerator.cs
@@ -674,6 +674,15 @@ namespace UnityEditor.ShaderGraph
                     materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
                     materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
                     break;
+                case AlphaMode.Transparent:
+                    materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.One;
+                    materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.OneMinusSrcAlpha;
+                    materialOptions.cullMode = twoSided ? SurfaceMaterialOptions.CullMode.Off : SurfaceMaterialOptions.CullMode.Back;
+                    materialOptions.zTest = SurfaceMaterialOptions.ZTest.LEqual;
+                    materialOptions.zWrite = SurfaceMaterialOptions.ZWrite.Off;
+                    materialOptions.renderQueue = SurfaceMaterialOptions.RenderQueue.Transparent;
+                    materialOptions.renderType = SurfaceMaterialOptions.RenderType.Transparent;
+                    break;
                 case AlphaMode.Additive:
                     materialOptions.srcBlend = SurfaceMaterialOptions.BlendMode.One;
                     materialOptions.dstBlend = SurfaceMaterialOptions.BlendMode.One;

--- a/com.unity.shadergraph/Editor/Templates/lightweightPBRExtraPasses.template
+++ b/com.unity.shadergraph/Editor/Templates/lightweightPBRExtraPasses.template
@@ -4,6 +4,7 @@ Pass
 
     ZWrite On
     ZTest LEqual
+    Cull ${Culling}
 
     HLSLPROGRAM
     // Required to compile gles 2.0 with standard srp library

--- a/com.unity.shadergraph/Editor/Templates/lightweightUnlitExtraPasses.template
+++ b/com.unity.shadergraph/Editor/Templates/lightweightUnlitExtraPasses.template
@@ -4,6 +4,7 @@ Pass
 
     ZWrite On
     ZTest LEqual
+    Cull ${Culling}
 
     HLSLPROGRAM
     // Required to compile gles 2.0 with standard srp library


### PR DESCRIPTION
**NOTE**
After discussion with HD team it is incredibly problematic to not have a distinction between opaque and transparent (due to Rough Refraction). In an effort for some unification between pipelines I have split the blend enum and renamed the entries to match theirs. Lightweight may also need to split, or just match mode namings.

- Split Blend enum into Surface and Blend enums
- Add two sided option to PBR and Unlit master nodes
- Add culling control to shadow pass (allow two sided shadow casting)
- Add Transparent (pre multuply alpha) blend mode
- Add Multiply blend mode
- Rename blend modes (AlphaBlend > Fade, AdditiveBlend > Additive)
- Add labels to Workflow and Blending dropdowns