### PR TITLE
PostLayoutEvent -> GeometryChangedEvent

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Inspector/MasterPreviewView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Inspector/MasterPreviewView.cs
@@ -8,6 +8,9 @@ using UnityEngine.Experimental.UIElements;
 using UnityEditor.Graphing;
 using UnityEngine.Experimental.UIElements.StyleSheets;
 using Object = UnityEngine.Object;
+#if UNITY_2018_1
+using GeometryChangedEvent = UnityEngine.Experimental.UIElements.PostLayoutEvent;
+#endif
 
 namespace UnityEditor.ShaderGraph.Drawing.Inspector
 {
@@ -154,12 +157,12 @@ namespace UnityEditor.ShaderGraph.Drawing.Inspector
 
         public void UpdateRenderTextureOnNextLayoutChange()
         {
-            RegisterCallback<PostLayoutEvent>(AdaptRenderTextureOnLayoutChange);
+            RegisterCallback<GeometryChangedEvent>(AdaptRenderTextureOnLayoutChange);
         }
 
-        void AdaptRenderTextureOnLayoutChange(PostLayoutEvent evt)
+        void AdaptRenderTextureOnLayoutChange(GeometryChangedEvent evt)
         {
-            UnregisterCallback<PostLayoutEvent>(AdaptRenderTextureOnLayoutChange);
+            UnregisterCallback<GeometryChangedEvent>(AdaptRenderTextureOnLayoutChange);
             RefreshRenderTextureSize();
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/Manipulators/ResizeSideHandle.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Manipulators/ResizeSideHandle.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using UnityEngine;
 using UnityEngine.Experimental.UIElements;
+#if UNITY_2018_1
+using GeometryChangedEvent = UnityEngine.Experimental.UIElements.PostLayoutEvent;
+#endif
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -123,12 +126,12 @@ namespace UnityEditor.ShaderGraph.Drawing
             RegisterCallback<MouseDownEvent>(HandleMouseDown);
             RegisterCallback<MouseUpEvent>(HandleDraggableMouseUp);
 
-            m_ResizeTarget.RegisterCallback<PostLayoutEvent>(InitialLayoutSetup);
+            m_ResizeTarget.RegisterCallback<GeometryChangedEvent>(InitialLayoutSetup);
         }
 
-        void InitialLayoutSetup(PostLayoutEvent evt)
+        void InitialLayoutSetup(GeometryChangedEvent evt)
         {
-            m_ResizeTarget.UnregisterCallback<PostLayoutEvent>(InitialLayoutSetup);
+            m_ResizeTarget.UnregisterCallback<GeometryChangedEvent>(InitialLayoutSetup);
             m_InitialAspectRatio = m_ResizeTarget.layout.width / m_ResizeTarget.layout.height;
         }
 

--- a/com.unity.shadergraph/Editor/Drawing/Manipulators/WindowDraggable.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Manipulators/WindowDraggable.cs
@@ -1,6 +1,9 @@
 ﻿﻿using System;
- using UnityEngine;
+using UnityEngine;
 using UnityEngine.Experimental.UIElements;
+#if UNITY_2018_1
+using GeometryChangedEvent = UnityEngine.Experimental.UIElements.PostLayoutEvent;
+#endif
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -35,7 +38,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_Handle.RegisterCallback(new EventCallback<MouseDownEvent>(OnMouseDown), Capture.NoCapture);
             m_Handle.RegisterCallback(new EventCallback<MouseMoveEvent>(OnMouseMove), Capture.NoCapture);
             m_Handle.RegisterCallback(new EventCallback<MouseUpEvent>(OnMouseUp), Capture.NoCapture);
-            target.RegisterCallback<PostLayoutEvent>(InitialLayoutSetup);
+            target.RegisterCallback<GeometryChangedEvent>(InitialLayoutSetup);
         }
 
         protected override void UnregisterCallbacksFromTarget()
@@ -85,16 +88,16 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        void InitialLayoutSetup(PostLayoutEvent postLayoutEvent)
+        void InitialLayoutSetup(GeometryChangedEvent GeometryChangedEvent)
         {
             m_PreviousParentRect = target.parent.layout;
-            target.UnregisterCallback<PostLayoutEvent>(InitialLayoutSetup);
-            target.RegisterCallback<PostLayoutEvent>(OnPostLayout);
+            target.UnregisterCallback<GeometryChangedEvent>(InitialLayoutSetup);
+            target.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
 
             m_WindowDockingLayout.CalculateDockingCornerAndOffset(target.layout, target.parent.layout);
         }
 
-        void OnPostLayout(PostLayoutEvent postLayoutEvent)
+        void OnGeometryChanged(GeometryChangedEvent GeometryChangedEvent)
         {
             Rect windowRect = target.layout;
 

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -6,10 +6,12 @@ using System.Text;
 using UnityEditor.Experimental.UIElements;
 using UnityEditor.Graphing.Util;
 using UnityEngine;
-using UnityEngine.Experimental.UIElements;
 using UnityEditor.Graphing;
 using Object = UnityEngine.Object;
 using Edge = UnityEditor.Experimental.UIElements.GraphView.Edge;
+#if UNITY_2018_1
+using GeometryChangedEvent = UnityEngine.Experimental.UIElements.PostLayoutEvent;
+#endif
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -113,7 +115,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                         node.Dirty(ModificationScope.Node);
                     forceRedrawPreviews = false;
                 }
-                    
+
                 graphEditorView.HandleGraphChanges();
                 graphObject.graph.ClearChanges();
             }
@@ -456,7 +458,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 graphObject.graph.ValidateGraph();
 
                 graphEditorView = new GraphEditorView(this, m_GraphObject.graph as AbstractMaterialGraph, asset.name) { persistenceKey = selectedGuid };
-                graphEditorView.RegisterCallback<PostLayoutEvent>(OnPostLayout);
+                graphEditorView.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
 
                 titleContent = new GUIContent(asset.name);
 
@@ -471,9 +473,9 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        void OnPostLayout(PostLayoutEvent evt)
+        void OnGeometryChanged(GeometryChangedEvent evt)
         {
-            graphEditorView.UnregisterCallback<PostLayoutEvent>(OnPostLayout);
+            graphEditorView.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
             graphEditorView.graphView.FrameAll();
         }
     }

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -8,6 +8,9 @@ using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph.Drawing.Inspector;
 using Edge = UnityEditor.Experimental.UIElements.GraphView.Edge;
 using Object = UnityEngine.Object;
+#if UNITY_2018_1
+using GeometryChangedEvent = UnityEngine.Experimental.UIElements.PostLayoutEvent;
+#endif
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -129,7 +132,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
                 m_GraphView.graphViewChanged = GraphViewChanged;
 
-                RegisterCallback<PostLayoutEvent>(ApplySerializewindowLayouts);
+                RegisterCallback<GeometryChangedEvent>(ApplySerializewindowLayouts);
             }
 
             m_SearchWindowProvider = ScriptableObject.CreateInstance<SearchWindowProvider>();
@@ -335,19 +338,19 @@ namespace UnityEditor.ShaderGraph.Drawing
                         continue;
                     if (port.slot.slotReference.Equals(m_SearchWindowProvider.targetSlotReference))
                     {
-                        port.RegisterCallback<PostLayoutEvent>(RepositionNode);
+                        port.RegisterCallback<GeometryChangedEvent>(RepositionNode);
                         return;
                     }
                 }
             }
         }
 
-        static void RepositionNode(PostLayoutEvent evt)
+        static void RepositionNode(GeometryChangedEvent evt)
         {
             var port = evt.target as ShaderPort;
             if (port == null)
                 return;
-            port.UnregisterCallback<PostLayoutEvent>(RepositionNode);
+            port.UnregisterCallback<GeometryChangedEvent>(RepositionNode);
             var nodeView = port.node as MaterialNodeView;
             if (nodeView == null)
                 return;
@@ -455,9 +458,9 @@ namespace UnityEditor.ShaderGraph.Drawing
             }
         }
 
-        void ApplySerializewindowLayouts(PostLayoutEvent evt)
+        void ApplySerializewindowLayouts(GeometryChangedEvent evt)
         {
-            UnregisterCallback<PostLayoutEvent>(ApplySerializewindowLayouts);
+            UnregisterCallback<GeometryChangedEvent>(ApplySerializewindowLayouts);
 
             if (m_FloatingWindowsLayout != null)
             {

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -9,6 +9,9 @@ using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEngine.Experimental.UIElements.StyleEnums;
 using Node = UnityEditor.Experimental.UIElements.GraphView.Node;
+#if UNITY_2018_1
+using GeometryChangedEvent = UnityEngine.Experimental.UIElements.PostLayoutEvent;
+#endif
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -339,7 +342,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 {
                     var portInputView = new PortInputView(port.slot) { style = { positionType = PositionType.Absolute } };
                     m_PortInputContainer.Add(portInputView);
-                    port.RegisterCallback<PostLayoutEvent>(evt => UpdatePortInput((ShaderPort)evt.target));
+                    port.RegisterCallback<GeometryChangedEvent>(evt => UpdatePortInput((ShaderPort)evt.target));
                 }
             }
         }


### PR DESCRIPTION
Reflect rename in future Unity versions of class PostLayoutEvent to GeometryChangedEvent (with fallback import for 2018.1). This gets us 1 step closer to compiling on trunk.