### PR TITLE
Fix Constant Node code gen

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Nodes/Channel/SwizzleNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Channel/SwizzleNode.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEngine;
@@ -131,7 +132,14 @@ namespace UnityEditor.ShaderGraph
             if (inputValueType == ConcreteSlotValueType.Vector1)
                 visitor.AddShaderChunk(string.Format("{0} {1} = {2};", outputSlotType, outputName, inputValue), false);
             else if (generationMode == GenerationMode.ForReals)
-                visitor.AddShaderChunk(string.Format("{0} {1} = {2}.{3}{4}{5}{6};", outputSlotType, outputName, inputValue, s_ComponentList[m_RedChannel], s_ComponentList[m_GreenChannel], s_ComponentList[m_BlueChannel], s_ComponentList[m_AlphaChannel]), false);
+                visitor.AddShaderChunk(string.Format("{0} {1} = {2}.{3}{4}{5}{6};", 
+                    outputSlotType, 
+                    outputName, 
+                    inputValue, 
+                    s_ComponentList[m_RedChannel].ToString(CultureInfo.InvariantCulture), 
+                    s_ComponentList[m_GreenChannel].ToString(CultureInfo.InvariantCulture), 
+                    s_ComponentList[m_BlueChannel].ToString(CultureInfo.InvariantCulture), 
+                    s_ComponentList[m_AlphaChannel].ToString(CultureInfo.InvariantCulture)), false);
             else
                 visitor.AddShaderChunk(string.Format("{0} {1} = {0}({3}[((int){2} >> 0) & 3], {3}[((int){2} >> 2) & 3], {3}[((int){2} >> 4) & 3], {3}[((int){2} >> 6) & 3]);",
                     outputSlotType,

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/ConstantNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Basic/ConstantNode.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEngine;
 using UnityEditor.Graphing;
@@ -60,7 +61,7 @@ namespace UnityEditor.ShaderGraph
 
         public void GenerateNodeCode(ShaderGenerator visitor, GenerationMode generationMode)
         {
-            visitor.AddShaderChunk(precision + " " + GetVariableNameForNode() + " = " + m_constantList[constant] + ";", true);
+            visitor.AddShaderChunk(precision + " " + GetVariableNameForNode() + " = " + m_constantList[constant].ToString(CultureInfo.InvariantCulture) + ";", true);
         }
 
         public override string GetVariableNameForSlot(int slotId)

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/TransformationMatrixNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/Matrix/TransformationMatrixNode.cs
@@ -1,5 +1,6 @@
 using UnityEditor.Graphing;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEngine;
 
@@ -68,7 +69,7 @@ namespace UnityEditor.ShaderGraph
 
         public override string GetVariableNameForSlot(int slotId)
         {
-            return m_matrixList[matrix];
+            return m_matrixList[matrix].ToString(CultureInfo.InvariantCulture);
         }
 
         public bool RequiresVertexColor()

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/PBR/DielectricSpecularNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/PBR/DielectricSpecularNode.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph.Drawing.Controls;
 using UnityEngine;
@@ -110,7 +111,7 @@ namespace UnityEditor.ShaderGraph
                     sb.AppendLine("{0}3 {1} = pow(_{2}_IOR - 1, 2) / pow(_{2}_IOR + 1, 2);", precision, GetVariableNameForSlot(kOutputSlotId), GetVariableNameForNode());
                     break;
                 default:
-                    sb.AppendLine("{0}3 {1} = {0}3{2};", precision, GetVariableNameForSlot(kOutputSlotId), m_MaterialList[material.type]);
+                    sb.AppendLine("{0}3 {1} = {0}3{2};", precision, GetVariableNameForSlot(kOutputSlotId), m_MaterialList[material.type].ToString(CultureInfo.InvariantCulture));
                     break;
             }
             visitor.AddShaderChunk(sb.ToString(), false);

--- a/com.unity.shadergraph/Editor/Data/Nodes/Input/PBR/MetalReflectanceNode.cs
+++ b/com.unity.shadergraph/Editor/Data/Nodes/Input/PBR/MetalReflectanceNode.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 using UnityEditor.Graphing;
 using UnityEditor.ShaderGraph.Drawing.Controls;
@@ -76,7 +77,7 @@ namespace UnityEditor.ShaderGraph
 
         public void GenerateNodeCode(ShaderGenerator visitor, GenerationMode generationMode)
         {
-            visitor.AddShaderChunk(string.Format("{0}3 {1} = {0}3{2};", precision, GetVariableNameForSlot(kOutputSlotId), m_MaterialList[material]), true);
+            visitor.AddShaderChunk(string.Format("{0}3 {1} = {0}3{2};", precision, GetVariableNameForSlot(kOutputSlotId), m_MaterialList[material].ToString(CultureInfo.InvariantCulture)), true);
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
+++ b/com.unity.shadergraph/Editor/Drawing/PreviewManager.cs
@@ -371,15 +371,14 @@ namespace UnityEditor.ShaderGraph.Drawing
                                 try
                                 {
                                     node = results.sourceMap.FindNode(error.line);
+                                    message.AppendLine("Shader compilation error in {3} at line {1} (on {2}):\n{0}", error.message, error.line, error.platform, node != null ? string.Format("node {0} ({1})", node.name, node.guid) : "graph");
+                                    message.AppendLine(error.messageDetails);
+                                    message.AppendNewLine();
                                 }
-                                catch (Exception e)
+                                catch
                                 {
-                                    Debug.LogException(e);
-                                    continue;
+                                    message.AppendLine("Shader compilation error in {3} at line {1} (on {2}):\n{0}", error.message, error.line, error.platform, "graph");
                                 }
-                                message.AppendLine("{0} in {3} at line {1} (on {2})", error.message, error.line, error.platform, node != null ? string.Format("node {0} ({1})", node.name, node.guid) : "graph");
-                                message.AppendLine(error.messageDetails);
-                                message.AppendNewLine();
                             }
                             Debug.LogWarning(message.ToString());
                             ShaderUtil.ClearShaderErrors(m_UberShader);


### PR DESCRIPTION
Fix float serialization in Constant Node to not be affected by system locale (was comma as decimal separator causing shader errors). It's likely that a bunch of other places also need this.