### PR TITLE
Fix: IsGammaSpace is undefined in the HD Unlit subshader

### DIFF
--- a/com.unity.shadergraph/Editor/Templates/HDUnlitPassForward.template
+++ b/com.unity.shadergraph/Editor/Templates/HDUnlitPassForward.template
@@ -25,6 +25,7 @@ Pass
     #include "HDRP/ShaderVariables.hlsl"
     #include "HDRP/ShaderPass/FragInputs.hlsl"
     #include "HDRP/ShaderPass/ShaderPass.cs.hlsl"
+    #include "ShaderGraphLibrary/Functions.hlsl"
 
     ${Defines}
     


### PR DESCRIPTION
In 1.0.0-beta, the following error occurs with any unlit graph.

```
Assertion failed: Assertion failed on expression: 'success'
UnityEditor.ShaderUtil:CreateShaderAsset(String)
ShaderGraphImporter:OnImportAsset(AssetImportContext)
...
```

From further investigation, I found `IsGammaSpace()` is undefined in the HD Unlit subshader.

This pull request is to fix the problem by simply adding `#include` to the shader template.