### PR TITLE
Fix for issue #271

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -441,7 +441,6 @@ namespace UnityEditor.ShaderGraph.Drawing
             AssetDatabase.ImportAsset(path);
         }
 
-
         private void Rebuild()
         {
             if (graphObject != null && graphObject.graph != null)

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -276,7 +276,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                     else
                     {
                         port.slot = newSlot;
-                        var portInputView = m_PortInputContainer.OfType<PortInputView>().FirstOrDefault(x => Equals(x.slot.id, currentSlot.id));
+                        var portInputView = m_PortInputContainer.OfType<PortInputView>().FirstOrDefault(x => x.slot.id == currentSlot.id);
                         portInputView.UpdateSlot(newSlot);
 
                         slots.Remove(newSlot);

--- a/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/MaterialNodeView.cs
@@ -276,6 +276,9 @@ namespace UnityEditor.ShaderGraph.Drawing
                     else
                     {
                         port.slot = newSlot;
+                        var portInputView = m_PortInputContainer.OfType<PortInputView>().FirstOrDefault(x => Equals(x.slot.id, currentSlot.id));
+                        portInputView.UpdateSlot(newSlot);
+
                         slots.Remove(newSlot);
                     }
                 }

--- a/com.unity.shadergraph/Editor/Drawing/Views/PortInputView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/PortInputView.cs
@@ -72,26 +72,37 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_EdgeControl.outputColor = edgeColor;
         }
 
+        public void UpdateSlot(MaterialSlot newSlot)
+        {
+            m_Slot = newSlot;
+            Recreate();
+        }
+
         public void UpdateSlotType()
         {
             if (slot.concreteValueType != m_SlotType)
             {
-                RemoveFromClassList("type" + m_SlotType);
-                m_SlotType = slot.concreteValueType;
-                AddToClassList("type" + m_SlotType);
-                if (m_Control != null)
-                {
-                    var disposable = m_Control as IDisposable;
-                    if (disposable != null)
-                        disposable.Dispose();
-                    m_Container.Remove(m_Control);
-                }
-                m_Control = slot.InstantiateControl();
-                if (m_Control != null)
-                    m_Container.Insert(0, m_Control);
-
-                m_Container.visible = m_EdgeControl.visible = m_Control != null;
+                Recreate();
             }
+        }
+
+        void Recreate()
+        {
+            RemoveFromClassList("type" + m_SlotType);
+            m_SlotType = slot.concreteValueType;
+            AddToClassList("type" + m_SlotType);
+            if (m_Control != null)
+            {
+                var disposable = m_Control as IDisposable;
+                if (disposable != null)
+                    disposable.Dispose();
+                m_Container.Remove(m_Control);
+            }
+            m_Control = slot.InstantiateControl();
+            if (m_Control != null)
+                m_Container.Insert(0, m_Control);
+
+            m_Container.visible = m_EdgeControl.visible = m_Control != null;
         }
 
         public void Dispose()

--- a/com.unity.shadergraph/Editor/Drawing/Views/PortInputView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/PortInputView.cs
@@ -81,9 +81,7 @@ namespace UnityEditor.ShaderGraph.Drawing
         public void UpdateSlotType()
         {
             if (slot.concreteValueType != m_SlotType)
-            {
                 Recreate();
-            }
         }
 
         void Recreate()


### PR DESCRIPTION
Making sure that the inputs on a referenced subgraph is editable at all times. 
Fix the issue that when saving a subgraph the link to the input container got lost and the user couldn't any longer change the default values inside the shader graph without reopening the shader graph.
