### PR TITLE
Fix warnings from legacy deserialization classes

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Graphs/SerializableCubemap.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/SerializableCubemap.cs
@@ -18,7 +18,9 @@ namespace UnityEditor.ShaderGraph
         [Serializable]
         class CubemapHelper
         {
+#pragma warning disable 649
             public Cubemap cubemap;
+#pragma warning restore 649
         }
 
         public Cubemap cubemap

--- a/com.unity.shadergraph/Editor/Data/Graphs/SerializableMesh.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/SerializableMesh.cs
@@ -18,7 +18,9 @@ namespace UnityEditor.ShaderGraph
         [Serializable]
         class MeshHelper
         {
+#pragma warning disable 649
             public Mesh mesh;
+#pragma warning restore 649
         }
 
         public Mesh mesh

--- a/com.unity.shadergraph/Editor/Data/Graphs/SerializableTexture.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/SerializableTexture.cs
@@ -18,7 +18,9 @@ namespace UnityEditor.ShaderGraph
         [Serializable]
         class TextureHelper
         {
+#pragma warning disable 649
             public Texture texture;
+#pragma warning restore 649
         }
 
         public Texture texture


### PR DESCRIPTION
Fix warnings from about unused variables that are kept there for legacy deserialization