### PR TITLE
Debugging features for generated code

### DIFF
--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporterEditor.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporterEditor.cs
@@ -1,21 +1,34 @@
+using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.Experimental.AssetImporters;
+using UnityEditor.ShaderGraph;
 using UnityEditor.ShaderGraph.Drawing;
 using UnityEngine;
 
 [CustomEditor(typeof(ShaderGraphImporter))]
 public class ShaderGraphImporterEditor : ScriptedImporterEditor
 {
+    static GenerationMode s_DebugGenerationMode = GenerationMode.ForReals;
+
     public override void OnInspectorGUI()
     {
+        AssetImporter importer = target as AssetImporter;
+
         if (GUILayout.Button("Open Shader Editor"))
         {
-            AssetImporter importer = target as AssetImporter;
             Debug.Assert(importer != null, "importer != null");
             ShowGraphEditWindow(importer.assetPath);
         }
+
+        EditorGUILayout.Space();
+
+        EditorGUILayout.BeginHorizontal();
+        s_DebugGenerationMode = (GenerationMode)EditorGUILayout.EnumPopup("Generated code", s_DebugGenerationMode);
+        if (GUILayout.Button("View", EditorStyles.miniButton, GUILayout.ExpandWidth(false)))
+            ShowGeneratedShader(importer.assetPath, s_DebugGenerationMode);
+        EditorGUILayout.EndHorizontal();
     }
 
     internal static bool ShowGraphEditWindow(string path)
@@ -42,6 +55,24 @@ public class ShaderGraphImporterEditor : ScriptedImporterEditor
             window.Initialize(guid);
         }
         return true;
+    }
+
+    internal static void ShowGeneratedShader(string path, GenerationMode generationMode)
+    {
+        var name = Path.GetFileNameWithoutExtension(path);
+
+        var json = File.ReadAllText(path, System.Text.Encoding.UTF8);
+        var graph = JsonUtility.FromJson<MaterialGraph>(json);
+        graph.LoadedFromDisk();
+
+        List<PropertyCollector.TextureInfo> textures;
+        var shaderName = string.Format("graphs/{0}", name);
+        var shaderString = graph.GetShader(shaderName, generationMode, out textures);
+
+        var tempPath = string.Format("Temp/GeneratedShader-{0}-{1}.shader", name, generationMode);
+        File.WriteAllText(tempPath, shaderString);
+
+        UnityEditorInternal.InternalEditorUtility.OpenFileAtLineExternal(tempPath, 0);
     }
 
     [OnOpenAsset(0)]


### PR DESCRIPTION
This PR is to add a few debugging features that may be useful for those who try to customize/extend Shader Graph.

- Added error output to the shader graph importer. It outputs error messages to the console view when the generated shader code has compilation errors/warnings.

![screenshot](https://i.imgur.com/FlGLYUO.png)

- Added "Generated code" item to the shader graph inspector. It has a drop down list to select generation mode (preview/for-reals) and "View" button that opens the generated shader code (temporarily saved into the Temp folder) with the external code editor.

![screenshot](https://i.imgur.com/PTk7ukU.png)

These features allow users to inspect problems happened in generated code with their own custom nodes and custom render pipelines.