### PR TITLE
[FIX] # 288

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Controls/ChannelEnumControl.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Controls/ChannelEnumControl.cs
@@ -34,6 +34,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
 
         public ChannelEnumControlView(string label, int slotId, AbstractMaterialNode node, PropertyInfo propertyInfo)
         {
+            AddStyleSheetPath("Styles/Controls/ChannelEnumControlView");
             m_Node = node;
             m_PropertyInfo = propertyInfo;
             m_SlotId = slotId;

--- a/com.unity.shadergraph/Editor/Drawing/Controls/ChannelEnumMaskControl.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Controls/ChannelEnumMaskControl.cs
@@ -34,6 +34,7 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
 
         public ChannelEnumMaskControlView(string label, int slotId, AbstractMaterialNode node, PropertyInfo propertyInfo)
         {
+            AddStyleSheetPath("Styles/Controls/ChannelEnumMaskControlView");
             m_Node = node;
             m_PropertyInfo = propertyInfo;
             m_SlotId = slotId;

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumControlView.uss
@@ -1,0 +1,9 @@
+ChannelEnumControlView {
+    flex-direction: row;
+    flex: 1;
+    padding-left: 8;
+    padding-right: 8;
+    padding-top: 4;
+    padding-bottom: 4;
+    width: 200;
+}

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumControlView.uss.meta
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumControlView.uss.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 8dfac6eef2d89e8428c7a79b147413db
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: stylesheet
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumMaskControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumMaskControlView.uss
@@ -1,0 +1,9 @@
+ChannelEnumMaskControlView {
+    flex-direction: row;
+    flex: 1;
+    padding-left: 8;
+    padding-right: 8;
+    padding-top: 4;
+    padding-bottom: 4;
+    width: 200;
+}

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumMaskControlView.uss.meta
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumMaskControlView.uss.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1db7b9bf1f9186d44ba7fefd3bc715c6
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: stylesheet
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}


### PR DESCRIPTION
Updated the ChannelEnum and ChannelEnumMask controls to use their own uss files. This solves the 5pixels extra width on the nodes using them.