### PR TITLE
Change path for graphs

### DIFF
--- a/com.unity.shadergraph/Editor/Data/Graphs/AbstractMaterialGraph.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/AbstractMaterialGraph.cs
@@ -148,6 +148,21 @@ namespace UnityEditor.ShaderGraph
             set { m_PreviewData = value; }
         }
 
+        [SerializeField]
+        string m_Path;
+
+        public string path
+        {
+            get { return m_Path; }
+            set
+            {
+                if (m_Path == value)
+                    return;
+                m_Path = value;
+                owner.RegisterCompleteObjectUndo("Change Path");
+            }
+        }
+
         public void ClearChanges()
         {
             m_AddedNodes.Clear();

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -44,7 +44,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             {
                 scrollable = true,
                 title = assetName.Split('/').Last(),
-                subTitle = graph.path,
+                subTitle = FormatPath(graph.path),
                 editTextRequested = EditTextRequested,
                 addItemRequested = AddItemRequested,
                 moveItemRequested = MoveItemRequested
@@ -126,13 +126,37 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_PathLabel.visible = true;
             m_PathLabelTextField.visible = false;
 
-            if (!m_EditPathCancelled && (m_PathLabel.text != m_PathLabelTextField.text) && (m_PathLabelTextField.text.Trim() != ""))
+            var newPath = m_PathLabelTextField.text;
+            if (!m_EditPathCancelled && (newPath != m_PathLabel.text))
             {
-                m_PathLabel.text = m_PathLabelTextField.text.Trim();
-                m_Graph.path = m_PathLabel.text;
+                newPath = SanitizePath(newPath);
             }
 
+            m_Graph.path = newPath;
+            m_PathLabel.text = FormatPath(newPath);
             m_EditPathCancelled = false;
+        }
+
+        static string FormatPath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return "—";
+            return path;
+        }
+
+        static string SanitizePath(string path)
+        {
+            var splitString = path.Split('/');
+            List<string> newStrings = new List<string>();
+            foreach (string s in splitString)
+            {
+                if (!string.IsNullOrWhiteSpace(s))
+                {
+                    newStrings.Add(s.Trim());
+                }
+            }
+
+            return string.Join("/", newStrings.ToArray());
         }
 
         void MoveItemRequested(Blackboard blackboard, int newIndex, VisualElement visualElement)

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -71,7 +71,6 @@ namespace UnityEditor.ShaderGraph.Drawing
             blackboard.Add(m_Section);
         }
 
-
         void OnMouseDownEvent(MouseDownEvent evt)
         {
             if (evt.clickCount == 2 && evt.button == (int)MouseButton.LeftMouse)

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -5,6 +5,8 @@ using UnityEditor.Experimental.UIElements.GraphView;
 using UnityEditor.Graphing;
 using UnityEngine;
 using UnityEngine.Experimental.UIElements;
+using UnityEngine.Experimental.UIElements.StyleEnums;
+using UnityEngine.Experimental.UIElements.StyleSheets;
 
 namespace UnityEditor.ShaderGraph.Drawing
 {
@@ -17,6 +19,7 @@ namespace UnityEditor.ShaderGraph.Drawing
         WindowDraggable m_WindowDraggable;
         ResizeBorderFrame m_ResizeBorderFrame;
         public Blackboard blackboard { get; private set; }
+        Label m_PathLabel;
 
         public Action onDragFinished
         {
@@ -40,10 +43,21 @@ namespace UnityEditor.ShaderGraph.Drawing
             {
                 scrollable = true,
                 title = assetName,
+                subTitle = "my awesome subtitle",
                 editTextRequested = EditTextRequested,
                 addItemRequested = AddItemRequested,
                 moveItemRequested = MoveItemRequested
             };
+
+            m_PathLabel = blackboard.shadow.ElementAt(0).Q<Label>("subTitleLabel");
+            m_PathLabel.RegisterCallback<MouseDownEvent>(OnMouseDownEvent);
+
+            /*
+             * 1. Register event on double click
+             * 2. Spawn a text field on top of the label using absolute position
+             *    (tip: add it to blackboard.parent)
+             * 3. Focus the text field using Focus
+             */
 
             m_WindowDraggable = new WindowDraggable(blackboard.shadow.Children().First().Q("header"));
             blackboard.AddManipulator(m_WindowDraggable);
@@ -56,6 +70,28 @@ namespace UnityEditor.ShaderGraph.Drawing
             foreach (var property in graph.properties)
                 AddProperty(property);
             blackboard.Add(m_Section);
+        }
+
+        void OnMouseDownEvent(MouseDownEvent evt)
+        {
+            if (evt.clickCount == 2 && evt.button == (int)MouseButton.LeftMouse)
+            {
+                StartEditingPath();
+            }
+        }
+
+        void StartEditingPath()
+        {
+            TextField tField = new TextField();
+            tField.text = "Muppet";
+            tField.style.positionType = PositionType.Absolute;
+            var position = m_PathLabel.ChangeCoordinatesTo(blackboard, Vector2.zero);
+            tField.style.positionLeft = position.x;
+            tField.style.positionTop = position.y;
+
+            blackboard.shadow.Add(tField);
+
+            Debug.Log(m_PathLabel.text);
         }
 
         void MoveItemRequested(Blackboard blackboard, int newIndex, VisualElement visualElement)

--- a/com.unity.shadergraph/Editor/Drawing/SearchWindowProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/SearchWindowProvider.cs
@@ -79,8 +79,9 @@ namespace UnityEditor.ShaderGraph.Drawing
                 foreach (var guid in AssetDatabase.FindAssets(string.Format("t:{0}", typeof(MaterialSubGraphAsset))))
                 {
                     var asset = AssetDatabase.LoadAssetAtPath<MaterialSubGraphAsset>(AssetDatabase.GUIDToAssetPath(guid));
+                    var title = asset.subGraph.path.Split('/').Append(asset.name).ToArray();
                     var node = new SubGraphNode { subGraphAsset = asset };
-                    AddEntries(node, new[] { "Sub-graph Assets", asset.name }, nodeEntries);
+                    AddEntries(node, title, nodeEntries);
                 }
             }
 

--- a/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
+++ b/com.unity.shadergraph/Editor/Importers/ShaderGraphImporter.cs
@@ -9,12 +9,12 @@ using UnityEditor;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEditor.ShaderGraph.Drawing;
 
-[ScriptedImporter(12, ShaderGraphImporter.ShaderGraphExtension)]
+[ScriptedImporter(13, ShaderGraphImporter.ShaderGraphExtension)]
 public class ShaderGraphImporter : ScriptedImporter
 {
     public const string ShaderGraphExtension = "shadergraph";
 
-    private string errorShader = @"
+    const string k_ErrorShader = @"
 Shader ""Hidden/GraphErrorShader2""
 {
     SubShader
@@ -64,14 +64,7 @@ Shader ""Hidden/GraphErrorShader2""
             ShaderUtil.ClearShaderErrors(oldShader);
 
         List<PropertyCollector.TextureInfo> configuredTextures;
-        var text = GetShaderText<MaterialGraph>(ctx.assetPath, out configuredTextures);
-        if (text == null)
-            text = errorShader;
-
-        var name = Path.GetFileNameWithoutExtension(ctx.assetPath);
-        string shaderName = string.Format("graphs/{0}", name);
-        text = text.Replace("Hidden/GraphErrorShader2", shaderName);
-
+        var text = GetShaderText(ctx.assetPath, out configuredTextures);
         var shader = ShaderUtil.CreateShaderAsset(text);
 
         EditorMaterialUtility.SetShaderDefaults(
@@ -87,25 +80,26 @@ Shader ""Hidden/GraphErrorShader2""
         ctx.SetMainObject(shader);
     }
 
-    private static string GetShaderText<T>(string path, out List<PropertyCollector.TextureInfo> configuredTextures) where T : IShaderGraph
+    static string GetShaderText(string path, out List<PropertyCollector.TextureInfo> configuredTextures)
     {
+        string shaderString = null;
+        var shaderName = Path.GetFileNameWithoutExtension(path);
         try
         {
             var textGraph = File.ReadAllText(path, Encoding.UTF8);
-            var graph = JsonUtility.FromJson<T>(textGraph);
+            var graph = JsonUtility.FromJson<MaterialGraph>(textGraph);
             graph.LoadedFromDisk();
 
-            var name = Path.GetFileNameWithoutExtension(path);
-            var shaderString = graph.GetShader(string.Format("graphs/{0}", name), GenerationMode.ForReals, out configuredTextures);
-            //Debug.Log(shaderString);
-            return shaderString;
+            if (!string.IsNullOrEmpty(graph.path))
+                shaderName = graph.path + "/" + shaderName;
+            shaderString = graph.GetShader(shaderName, GenerationMode.ForReals, out configuredTextures);
         }
         catch (Exception)
         {
             // ignored
         }
         configuredTextures = new List<PropertyCollector.TextureInfo>();
-        return null;
+        return shaderString ?? k_ErrorShader.Replace("Hidden/GraphErrorShader2", shaderName);
     }
 }
 


### PR DESCRIPTION
Enables the user to change the path of Shader Graphs and Sub Graphs as requested in issue #289. Changing the path of a Shader Graph modifies the location it has in the shader selection list. Likewise changing the path of Sub Graph modifies its location in the node creation menu.