### PR TITLE
Update ChannelEnumControl to UIElements and USS

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Controls/ChannelEnumControl.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Controls/ChannelEnumControl.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
 using UnityEditor.Graphing;
 using UnityEngine.Experimental.UIElements;
+using UnityEditor.Experimental.UIElements;
 
 namespace UnityEditor.ShaderGraph.Drawing.Controls
 {
@@ -26,11 +28,12 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
 
     public class ChannelEnumControlView : VisualElement, INodeModificationListener
     {
-        GUIContent m_Label;
         AbstractMaterialNode m_Node;
         PropertyInfo m_PropertyInfo;
-        IMGUIContainer m_Container;
         int m_SlotId;
+
+        PopupField<string> m_PopupField;
+        string[] m_ValueNames;
 
         public ChannelEnumControlView(string label, int slotId, AbstractMaterialNode node, PropertyInfo propertyInfo)
         {
@@ -40,41 +43,49 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
             m_SlotId = slotId;
             if (!propertyInfo.PropertyType.IsEnum)
                 throw new ArgumentException("Property must be an enum.", "propertyInfo");
-            m_Label = new GUIContent(label ?? ObjectNames.NicifyVariableName(propertyInfo.Name));
-            m_Container = new IMGUIContainer(OnGUIHandler);
-            Add(m_Container);
+            Add(new Label(label ?? ObjectNames.NicifyVariableName(propertyInfo.Name)));
+
+            var value = (Enum)m_PropertyInfo.GetValue(m_Node, null);
+            m_ValueNames = Enum.GetNames(value.GetType());
+            
+            CreatePopup();
         }
 
-        void OnGUIHandler()
+        void OnValueChanged(ChangeEvent<string> evt)
         {
-            UpdatePopup();
+            var index = m_PopupField.index;
+            var value = (int)m_PropertyInfo.GetValue(m_Node, null);
+            if (!index.Equals(value))
+            {
+                m_Node.owner.owner.RegisterCompleteObjectUndo("Change " + m_Node.name);
+                m_PropertyInfo.SetValue(m_Node, index, null);
+            }
+
+            CreatePopup();
         }
 
         public void OnNodeModified(ModificationScope scope)
         {
-            if (scope == ModificationScope.Graph)
-                m_Container.Dirty(ChangeType.Repaint);
+            if (scope == ModificationScope.Node)
+            {
+                CreatePopup();
+                m_PopupField.Dirty(ChangeType.Repaint);
+            } 
         }
 
-        private void UpdatePopup()
+        void CreatePopup()
         {
-            var value = (int)m_PropertyInfo.GetValue(m_Node, null);
-            using (var changeCheckScope = new EditorGUI.ChangeCheckScope())
-            {
-                int channelCount = SlotValueHelper.GetChannelCount(m_Node.FindSlot<MaterialSlot>(m_SlotId).concreteValueType);
-                var enumEntryCount = (Enum)m_PropertyInfo.GetValue(m_Node, null);
-                string[] enumEntryNames = Enum.GetNames(enumEntryCount.GetType());
-                string[] popupEntries = new string[channelCount];
-                for (int i = 0; i < popupEntries.Length; i++)
-                    popupEntries[i] = enumEntryNames[i];
-                value = EditorGUILayout.Popup(m_Label, value, popupEntries);
+            if(m_PopupField != null)
+                Remove(m_PopupField);
+            
+            int channelCount = SlotValueHelper.GetChannelCount(m_Node.FindSlot<MaterialSlot>(m_SlotId).concreteValueType);
+            List<string> popupEntries = new List<string>();
+            for (int i = 0; i < channelCount; i++)
+                popupEntries.Add(m_ValueNames[i]);
 
-                if (changeCheckScope.changed)
-                {
-                    m_Node.owner.owner.RegisterCompleteObjectUndo("Change " + m_Node.name);
-                    m_PropertyInfo.SetValue(m_Node, value, null);
-                }
-            }
+            m_PopupField = new PopupField<string>(popupEntries, (int)m_PropertyInfo.GetValue(m_Node, null));
+            m_PopupField.OnValueChanged(OnValueChanged);
+            Add(m_PopupField);
         }
     }
 }

--- a/com.unity.shadergraph/Editor/Drawing/Controls/ChannelEnumControl.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Controls/ChannelEnumControl.cs
@@ -35,6 +35,8 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
         PopupField<string> m_PopupField;
         string[] m_ValueNames;
 
+        int m_PreviousChannelCount = -1;
+
         public ChannelEnumControlView(string label, int slotId, AbstractMaterialNode node, PropertyInfo propertyInfo)
         {
             AddStyleSheetPath("Styles/Controls/ChannelEnumControlView");
@@ -75,15 +77,26 @@ namespace UnityEditor.ShaderGraph.Drawing.Controls
 
         void CreatePopup()
         {
-            if(m_PopupField != null)
-                Remove(m_PopupField);
-            
             int channelCount = SlotValueHelper.GetChannelCount(m_Node.FindSlot<MaterialSlot>(m_SlotId).concreteValueType);
+
+            if(m_PopupField != null)
+            {
+                if(channelCount == m_PreviousChannelCount)
+                    return;
+
+                Remove(m_PopupField);
+            }
+            
+            m_PreviousChannelCount = channelCount;
             List<string> popupEntries = new List<string>();
             for (int i = 0; i < channelCount; i++)
                 popupEntries.Add(m_ValueNames[i]);
 
-            m_PopupField = new PopupField<string>(popupEntries, (int)m_PropertyInfo.GetValue(m_Node, null));
+            var value = (int)m_PropertyInfo.GetValue(m_Node, null);
+            if(value >= channelCount)
+                value = 0;
+
+            m_PopupField = new PopupField<string>(popupEntries, value);
             m_PopupField.OnValueChanged(OnValueChanged);
             Add(m_PopupField);
         }

--- a/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumControlView.uss
+++ b/com.unity.shadergraph/Editor/Resources/Styles/Controls/ChannelEnumControlView.uss
@@ -1,9 +1,24 @@
 ChannelEnumControlView {
     flex-direction: row;
-    flex: 1;
-    padding-left: 8;
-    padding-right: 8;
-    padding-top: 4;
-    padding-bottom: 4;
-    width: 200;
+}
+
+ChannelEnumControlView > .popupField {
+    width: 76;
+    flex: 0;
+    margin-left: 0;
+    margin-right: 8;
+    margin-top: 4;
+    margin-bottom: 4;
+}
+
+ChannelEnumControlView > Label {
+    width: 100;
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    margin-left: 8;
+    margin-right: 8;
+    margin-top: 4;
+    margin-bottom: 4;
 }


### PR DESCRIPTION
Minor PR. Updates the ChannelEnumControl to use `PopupField` from UIElements instead of the old `EditorGUILayout.Popup`.

Some things to note:
- Have to recreate the popup field every time the node or the control are modified.
- This control now suffers the same lack of update response when changing input connections (see https://favro.com/card/c564ede4ed3337f7b17986b6/Uni-37652)