### PR TITLE
Makes display name override the reference name.

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardField.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardField.cs
@@ -138,7 +138,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 case KeyCode.LeftArrow:
                     break;
                 default:
-                    if(!Char.IsLetterOrDigit(e.character)) e.PreventDefault();
+                    if(!Char.IsLetterOrDigit(e.character) && e.character != '_') e.PreventDefault();
                     break;
             }
         }

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardField.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardField.cs
@@ -132,7 +132,13 @@ namespace UnityEditor.ShaderGraph.Drawing
                 case KeyCode.KeypadEnter:
                     m_TextField.Blur();
                     break;
+                case KeyCode.Backspace:
+                case KeyCode.Delete:
+                case KeyCode.RightArrow:
+                case KeyCode.LeftArrow:
+                    break;
                 default:
+                    if(!Char.IsLetterOrDigit(e.character)) e.PreventDefault();
                     break;
             }
         }

--- a/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Blackboard/BlackboardProvider.cs
@@ -191,6 +191,7 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_Graph.owner.RegisterCompleteObjectUndo("Edit Property Name");
                 newText = m_Graph.SanitizePropertyName(newText, property.guid);
                 property.displayName = newText;
+                property.overrideReferenceName = newText;
                 field.text = newText;
                 DirtyNodes();
             }


### PR DESCRIPTION
Overrides the reference name to the display name to allow compiling the property under it's display name. This allow easier interfacing from scripts and animation. Also forced the property text field to accept only alphanumeric characters, this enforces proper naming for the variables.