### PR TITLE
Node placement copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ The property reference names are now editable. It is also now possible to make t
 - Fixed an issue where vector 1 node was not evaluating properly. ([#334](https://github.com/Unity-Technologies/ShaderGraph/issues/334) and [#337](https://github.com/Unity-Technologies/ShaderGraph/issues/337))
 - Properties can now be copied and pasted.
 - Pasting a property node into another graph will now convert it to a concrete node. ([#300](https://github.com/Unity-Technologies/ShaderGraph/issues/300))
+- Make nodes that are copied from one graph to another spawn in the center of the current view. ([#333](https://github.com/Unity-Technologies/ShaderGraph/issues/333))

--- a/com.unity.shadergraph/Editor/Data/Graphs/SerializableGuid.cs
+++ b/com.unity.shadergraph/Editor/Data/Graphs/SerializableGuid.cs
@@ -11,6 +11,11 @@ namespace UnityEditor.ShaderGraph
             m_Guid = Guid.NewGuid();
         }
 
+        public SerializableGuid(Guid guid)
+        {
+            m_Guid = guid;
+        }
+
         [NonSerialized]
         private Guid m_Guid;
 

--- a/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
+++ b/com.unity.shadergraph/Editor/Drawing/MaterialGraphEditWindow.cs
@@ -239,6 +239,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             var metaProperties = graphView.graph.properties.Where(x => propertyNodeGuids.Contains(x.guid));
 
             var copyPasteGraph = new CopyPasteGraph(
+                    graphView.graph.guid,
                     graphView.selection.OfType<MaterialNodeView>().Where(x => !(x.node is PropertyNode)).Select(x => x.node as INode),
                     graphView.selection.OfType<Edge>().Select(x => x.userData as IEdge),
                     graphView.selection.OfType<BlackboardField>().Select(x => x.userData as IShaderProperty),

--- a/com.unity.shadergraph/Editor/Util/CopyPasteGraph.cs
+++ b/com.unity.shadergraph/Editor/Util/CopyPasteGraph.cs
@@ -24,6 +24,9 @@ namespace UnityEditor.Graphing.Util
         [NonSerialized]
         HashSet<IShaderProperty> m_MetaProperties = new HashSet<IShaderProperty>();
 
+        [NonSerialized]
+        SerializableGuid m_SourceGraphGuid;
+
         [SerializeField]
         List<SerializationHelper.JSONSerializedElement> m_SerializableNodes = new List<SerializationHelper.JSONSerializedElement>();
 
@@ -36,10 +39,15 @@ namespace UnityEditor.Graphing.Util
         [SerializeField]
         List<SerializationHelper.JSONSerializedElement> m_SerializableMetaProperties = new List<SerializationHelper.JSONSerializedElement>();
 
+        [SerializeField]
+        SerializationHelper.JSONSerializedElement m_SerializeableSourceGraphGuid = new SerializationHelper.JSONSerializedElement();
+
         public CopyPasteGraph() {}
 
-        public CopyPasteGraph(IEnumerable<INode> nodes, IEnumerable<IEdge> edges, IEnumerable<IShaderProperty> properties, IEnumerable<IShaderProperty> metaProperties)
+        public CopyPasteGraph(Guid sourceGraphGuid, IEnumerable<INode> nodes, IEnumerable<IEdge> edges, IEnumerable<IShaderProperty> properties, IEnumerable<IShaderProperty> metaProperties)
         {
+            m_SourceGraphGuid = new SerializableGuid(sourceGraphGuid);
+
             foreach (var node in nodes)
             {
                 AddNode(node);
@@ -97,8 +105,14 @@ namespace UnityEditor.Graphing.Util
             get { return m_MetaProperties; }
         }
 
+        public Guid sourceGraphGuid
+        {
+            get { return m_SourceGraphGuid.guid; }
+        }
+
         public void OnBeforeSerialize()
         {
+            m_SerializeableSourceGraphGuid = SerializationHelper.Serialize(m_SourceGraphGuid);
             m_SerializableNodes = SerializationHelper.Serialize<INode>(m_Nodes);
             m_SerializableEdges = SerializationHelper.Serialize<IEdge>(m_Edges);
             m_SerilaizeableProperties = SerializationHelper.Serialize<IShaderProperty>(m_Properties);
@@ -107,6 +121,8 @@ namespace UnityEditor.Graphing.Util
 
         public void OnAfterDeserialize()
         {
+            m_SourceGraphGuid = SerializationHelper.Deserialize<SerializableGuid>(m_SerializeableSourceGraphGuid, GraphUtil.GetLegacyTypeRemapping());
+
             var nodes = SerializationHelper.Deserialize<INode>(m_SerializableNodes, GraphUtil.GetLegacyTypeRemapping());
             m_Nodes.Clear();
             foreach (var node in nodes)


### PR DESCRIPTION
Makes copied nodes spawn in the center of the current view when copied from another graph.

This fixes #333