### PR TITLE
Fix obsolete warnings

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/Manipulators/Draggable.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Manipulators/Draggable.cs
@@ -25,21 +25,21 @@ namespace UnityEditor.ShaderGraph.Drawing
 
         protected override void RegisterCallbacksOnTarget()
         {
-            target.RegisterCallback(new EventCallback<MouseDownEvent>(OnMouseDown), Capture.NoCapture);
-            target.RegisterCallback(new EventCallback<MouseMoveEvent>(OnMouseMove), Capture.NoCapture);
-            target.RegisterCallback(new EventCallback<MouseUpEvent>(OnMouseUp), Capture.NoCapture);
+            target.RegisterCallback(new EventCallback<MouseDownEvent>(OnMouseDown), TrickleDownEnum.NoTrickleDown);
+            target.RegisterCallback(new EventCallback<MouseMoveEvent>(OnMouseMove), TrickleDownEnum.NoTrickleDown);
+            target.RegisterCallback(new EventCallback<MouseUpEvent>(OnMouseUp), TrickleDownEnum.NoTrickleDown);
         }
 
         protected override void UnregisterCallbacksFromTarget()
         {
-            target.UnregisterCallback(new EventCallback<MouseDownEvent>(OnMouseDown), Capture.NoCapture);
-            target.UnregisterCallback(new EventCallback<MouseMoveEvent>(OnMouseMove), Capture.NoCapture);
-            target.UnregisterCallback(new EventCallback<MouseUpEvent>(OnMouseUp), Capture.NoCapture);
+            target.UnregisterCallback(new EventCallback<MouseDownEvent>(OnMouseDown), TrickleDownEnum.NoTrickleDown);
+            target.UnregisterCallback(new EventCallback<MouseMoveEvent>(OnMouseMove), TrickleDownEnum.NoTrickleDown);
+            target.UnregisterCallback(new EventCallback<MouseUpEvent>(OnMouseUp), TrickleDownEnum.NoTrickleDown);
         }
 
         void OnMouseDown(MouseDownEvent evt)
         {
-            target.TakeMouseCapture();
+            target.CaptureMouse();
             m_Active = true;
             evt.StopPropagation();
         }
@@ -65,7 +65,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             if (target.HasMouseCapture())
             {
-                target.ReleaseMouseCapture();
+                target.ReleaseMouse();
             }
 
             evt.StopPropagation();

--- a/com.unity.shadergraph/Editor/Drawing/Manipulators/ResizeSideHandle.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Manipulators/ResizeSideHandle.cs
@@ -330,7 +330,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_ResizeBeginMousePosition = mouseDownEvent.mousePosition;
 
             m_Dragging = true;
-            this.TakeMouseCapture();
+            this.CaptureMouse();
             mouseDownEvent.StopPropagation();
         }
 
@@ -339,7 +339,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             m_Dragging = false;
 
             if (this.HasMouseCapture())
-                this.ReleaseMouseCapture();
+                this.ReleaseMouse();
 
             if (OnResizeFinished != null)
                 OnResizeFinished();

--- a/com.unity.shadergraph/Editor/Drawing/Manipulators/WindowDraggable.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Manipulators/WindowDraggable.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEditor.Experimental.UIElements.GraphView;
 using UnityEngine.Experimental.UIElements;
 using UnityEngine.Experimental.UIElements.StyleSheets;
+
 #if UNITY_2018_1
 using GeometryChangedEvent = UnityEngine.Experimental.UIElements.PostLayoutEvent;
 #endif
@@ -36,17 +37,17 @@ namespace UnityEditor.ShaderGraph.Drawing
         {
             if (m_Handle == null)
                 m_Handle = target;
-            m_Handle.RegisterCallback(new EventCallback<MouseDownEvent>(OnMouseDown), Capture.NoCapture);
-            m_Handle.RegisterCallback(new EventCallback<MouseMoveEvent>(OnMouseMove), Capture.NoCapture);
-            m_Handle.RegisterCallback(new EventCallback<MouseUpEvent>(OnMouseUp), Capture.NoCapture);
+            m_Handle.RegisterCallback(new EventCallback<MouseDownEvent>(OnMouseDown), TrickleDownEnum.NoTrickleDown);
+            m_Handle.RegisterCallback(new EventCallback<MouseMoveEvent>(OnMouseMove), TrickleDownEnum.NoTrickleDown);
+            m_Handle.RegisterCallback(new EventCallback<MouseUpEvent>(OnMouseUp), TrickleDownEnum.NoTrickleDown);
             target.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
         }
 
         protected override void UnregisterCallbacksFromTarget()
         {
-            m_Handle.UnregisterCallback(new EventCallback<MouseDownEvent>(OnMouseDown), Capture.NoCapture);
-            m_Handle.UnregisterCallback(new EventCallback<MouseMoveEvent>(OnMouseMove), Capture.NoCapture);
-            m_Handle.UnregisterCallback(new EventCallback<MouseUpEvent>(OnMouseUp), Capture.NoCapture);
+            m_Handle.UnregisterCallback(new EventCallback<MouseDownEvent>(OnMouseDown), TrickleDownEnum.NoTrickleDown);
+            m_Handle.UnregisterCallback(new EventCallback<MouseMoveEvent>(OnMouseMove), TrickleDownEnum.NoTrickleDown);
+            m_Handle.UnregisterCallback(new EventCallback<MouseUpEvent>(OnMouseUp), TrickleDownEnum.NoTrickleDown);
             target.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
             if (m_GraphView != null)
                 m_GraphView.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
@@ -68,7 +69,7 @@ namespace UnityEditor.ShaderGraph.Drawing
             // to the mouse position.
             m_LocalMosueOffset = m_Handle.WorldToLocal(evt.mousePosition);
 
-            m_Handle.TakeMouseCapture();
+            m_Handle.CaptureMouse();
             evt.StopImmediatePropagation();
         }
 
@@ -102,7 +103,7 @@ namespace UnityEditor.ShaderGraph.Drawing
 
             if (m_Handle.HasMouseCapture())
             {
-                m_Handle.ReleaseMouseCapture();
+                m_Handle.ReleaseMouse();
             }
 
             evt.StopImmediatePropagation();

--- a/com.unity.shadergraph/Editor/Util/CompatibilityExtensions.cs
+++ b/com.unity.shadergraph/Editor/Util/CompatibilityExtensions.cs
@@ -54,5 +54,28 @@ namespace UnityEditor.ShaderGraph.Drawing
             element.Dirty(ChangeType.Repaint);
         }
 #endif
+
+#if !UNITY_2018_3_OR_NEWER
+        public static void CaptureMouse(this VisualElement element)
+        {
+            element.TakeMouseCapture();
+        }
+
+        public static void ReleaseMouse(this VisualElement element)
+        {
+            element.ReleaseMouseCapture();
+        }
+#endif
+    }
+
+    static class TrickleDownEnum
+    {
+#if UNITY_2018_3_OR_NEWER
+        public static readonly TrickleDown NoTrickleDown = TrickleDown.NoTrickleDown;
+        public static readonly TrickleDown TrickleDown = TrickleDown.TrickleDown;
+#else
+        public static readonly Capture NoTrickleDown = Capture.NoCapture;
+        public static readonly Capture TrickleDown = Capture.Capture;
+#endif
     }
 }


### PR DESCRIPTION
Capturemouse event and trickle down enum has changed and this is a fix for that so it is compatible with older versions.