### PR TITLE
Fix null refs in search window provider

### DIFF
--- a/com.unity.shadergraph/Editor/Drawing/SearchWindowProvider.cs
+++ b/com.unity.shadergraph/Editor/Drawing/SearchWindowProvider.cs
@@ -79,7 +79,8 @@ namespace UnityEditor.ShaderGraph.Drawing
                 foreach (var guid in AssetDatabase.FindAssets(string.Format("t:{0}", typeof(MaterialSubGraphAsset))))
                 {
                     var asset = AssetDatabase.LoadAssetAtPath<MaterialSubGraphAsset>(AssetDatabase.GUIDToAssetPath(guid));
-                    var title = asset.subGraph.path.Split('/').ToList();
+                    var path = asset.subGraph.path ?? "";
+                    var title = path.Split('/').ToList();
                     title.Add(asset.name);
                     var node = new SubGraphNode { subGraphAsset = asset };
                     AddEntries(node, title.ToArray(), nodeEntries);


### PR DESCRIPTION
This PR fixes an issue introduced with editable sub graph paths, causing the search window to sometimes yield a null reference exception.