### PR TITLE
Ensure the blackboard remains in view after deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@ This adds gradient functionality via two new nodes. Sample Gradient node samples
 - Pasting a property node into another graph will now convert it to a concrete node. ([#300](https://github.com/Unity-Technologies/ShaderGraph/issues/300) and [#307](https://github.com/Unity-Technologies/ShaderGraph/pull/307))
 - Make nodes that are copied from one graph to another spawn in the center of the current view. ([#333](https://github.com/Unity-Technologies/ShaderGraph/issues/333))
 - Fixed an issue with editable sub graph paths, causing the search window to sometimes yield a null reference exception.
+- Ensure that the blackboard is within view when deserialized.

--- a/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
+++ b/com.unity.shadergraph/Editor/Drawing/Views/GraphEditorView.cs
@@ -481,8 +481,19 @@ namespace UnityEditor.ShaderGraph.Drawing
                 m_MasterPreviewView.previewTextureView.style.width = StyleValue<float>.Create(m_FloatingWindowsLayout.masterPreviewSize.x);
                 m_MasterPreviewView.previewTextureView.style.height = StyleValue<float>.Create(m_FloatingWindowsLayout.masterPreviewSize.y);
 
-                // Restore blackboard layout
-                m_BlackboardProvider.blackboard.layout = m_FloatingWindowsLayout.blackboardLayout.GetLayout(this.layout);
+                // Restore blackboard layout, and make sure that it remains in the view.
+                Rect blackboardRect = m_FloatingWindowsLayout.blackboardLayout.GetLayout(this.layout);
+
+                // Make sure the dimensions are sufficiently large.
+                blackboardRect.width = Mathf.Clamp(blackboardRect.width, 160f, m_GraphView.contentContainer.layout.width);
+                blackboardRect.height = Mathf.Clamp(blackboardRect.height, 160f, m_GraphView.contentContainer.layout.height);
+
+                // Make sure that the positionining is on screen.
+                blackboardRect.x = Mathf.Clamp(blackboardRect.x, 0f, Mathf.Max(1f, m_GraphView.contentContainer.layout.width - blackboardRect.width - blackboardRect.width));
+                blackboardRect.y = Mathf.Clamp(blackboardRect.y, 0f, Mathf.Max(1f, m_GraphView.contentContainer.layout.height - blackboardRect.height - blackboardRect.height));
+
+                // Set the processed blackboard layout.
+                m_BlackboardProvider.blackboard.layout = blackboardRect;
 
                 previewManager.ResizeMasterPreview(m_FloatingWindowsLayout.masterPreviewSize);
             }


### PR DESCRIPTION
Should resolve issues with the blackboard missing as reported in issues #353  and #365. However, I have not managed to reproduce the exact issue with the blackboard missing. The fix should ensure that the blackboard is at least not missing from the graph due to old/incompatible serialization.